### PR TITLE
Feat: Add dialog to enable student to edit their basic information

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,3 +87,8 @@
     -moz-appearance: textfield !important;
   }
 }
+
+/* This is used by the CalendarWithDropdows component */
+.rdp-vhidden {
+  @apply hidden;
+}

--- a/src/components/student-profile/student-info-edit-dialog.tsx
+++ b/src/components/student-profile/student-info-edit-dialog.tsx
@@ -11,8 +11,8 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 
-import { LoadingSpinner } from '@/components/loading-spinner'
-import { useSession } from 'next-auth/react'
+// import { LoadingSpinner } from '@/components/loading-spinner'
+// import { useSession } from 'next-auth/react'
 import { Settings, CalendarIcon } from 'lucide-react'
 
 import { useState } from 'react'
@@ -49,7 +49,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 
-import { Calendar } from '@/components/ui/calendar'
+import { CalendarWithDropdowns } from '../ui/calendar-with-dropdowns'
 import { format } from 'date-fns'
 import { ptBR } from 'date-fns/locale'
 import { cn, formatPhone } from '@/lib/utils'
@@ -167,36 +167,6 @@ const EditInfoDialogContent = ({
           <div>
             <FormField
               control={form.control}
-              name="course"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Curso</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Selecione o seu curso" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="Ciência da Computação">
-                        Ciência da Computação
-                      </SelectItem>
-                      <SelectItem value="Engenharia de Computação">
-                        Engenharia de Computação
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-          <div>
-            <FormField
-              control={form.control}
               name="birthDate"
               render={({ field }) => (
                 <FormItem>
@@ -220,7 +190,7 @@ const EditInfoDialogContent = ({
                         </Button>
                       </PopoverTrigger>
                       <PopoverContent className="w-auto p-0" align="start">
-                        <Calendar
+                        <CalendarWithDropdowns
                           locale={ptBR}
                           defaultMonth={field.value}
                           mode="single"
@@ -229,11 +199,43 @@ const EditInfoDialogContent = ({
                           disabled={(date) =>
                             date > new Date() || date < new Date('1900-01-01')
                           }
-                          // initialFocus
+                          captionLayout="dropdown-buttons"
+                          fromYear={1980}
+                          toYear={new Date().getFullYear()}
                         />
                       </PopoverContent>
                     </Popover>
                   </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div>
+            <FormField
+              control={form.control}
+              name="course"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Curso</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Selecione o seu curso" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="Ciência da Computação">
+                        Ciência da Computação
+                      </SelectItem>
+                      <SelectItem value="Engenharia de Computação">
+                        Engenharia de Computação
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
                   <FormMessage />
                 </FormItem>
               )}
@@ -352,20 +354,20 @@ const EditInfoDialogContent = ({
   )
 }
 
-function LoadingDialogContent(props: { title: string; message: string }) {
-  return (
-    <>
-      <DialogHeader>
-        <DialogTitle>{props.title}</DialogTitle>
-        <DialogDescription>{props.message}</DialogDescription>
-      </DialogHeader>
-      <div className="flex flex-col items-center justify-center w-full h-[160px]">
-        <LoadingSpinner size={50}></LoadingSpinner>
-        <p>Carregando...</p>
-      </div>
-    </>
-  )
-}
+// function LoadingDialogContent(props: { title: string; message: string }) {
+//   return (
+//     <>
+//       <DialogHeader>
+//         <DialogTitle>{props.title}</DialogTitle>
+//         <DialogDescription>{props.message}</DialogDescription>
+//       </DialogHeader>
+//       <div className="flex flex-col items-center justify-center w-full h-[160px]">
+//         <LoadingSpinner size={50}></LoadingSpinner>
+//         <p>Carregando...</p>
+//       </div>
+//     </>
+//   )
+// }
 
 export function StudentInfoEditDialog({
   studentData,

--- a/src/components/student-profile/student-info-edit-dialog.tsx
+++ b/src/components/student-profile/student-info-edit-dialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 
-// import { LoadingSpinner } from '@/components/loading-spinner'
+import { LoadingSpinner } from '@/components/loading-spinner'
 import { useSession } from 'next-auth/react'
 import { Settings, CalendarIcon } from 'lucide-react'
 
@@ -388,21 +388,6 @@ const EditInfoDialogContent = ({
   )
 }
 
-// function LoadingDialogContent(props: { title: string; message: string }) {
-//   return (
-//     <>
-//       <DialogHeader>
-//         <DialogTitle>{props.title}</DialogTitle>
-//         <DialogDescription>{props.message}</DialogDescription>
-//       </DialogHeader>
-//       <div className="flex flex-col items-center justify-center w-full h-[160px]">
-//         <LoadingSpinner size={50}></LoadingSpinner>
-//         <p>Carregando...</p>
-//       </div>
-//     </>
-//   )
-// }
-
 export function StudentInfoEditDialog({
   studentData,
   setStudentData,
@@ -411,6 +396,7 @@ export function StudentInfoEditDialog({
   setStudentData: Dispatch<SetStateAction<StudentResponse | null>>
 }) {
   const [showDialog, setShowDialog] = useState<boolean>(false)
+  const [loading, setLoading] = useState<boolean>(false)
   const { data } = useSession()
   const { toast } = useToast()
 
@@ -450,6 +436,10 @@ export function StudentInfoEditDialog({
 
   const submitHandler = async (formData: EditInfoSchema) => {
     const requestData: StudentEditRequest = formatInfoEditData(formData)
+
+    setLoading(true)
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
 
     try {
       const url = `${process.env.backendRoute}/api/v1/students/${studentData.email}`
@@ -496,6 +486,11 @@ export function StudentInfoEditDialog({
         description: 'Erro ao enviar os dados.',
       })
     }
+
+    // This is required to prevent weird ui behavior when closing the modal
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    setLoading(false)
   }
 
   return (
@@ -514,9 +509,18 @@ export function StudentInfoEditDialog({
               informações pessoais para manter seu perfil correto e atualizado.
             </DialogDescription>
           </DialogHeader>
-          <ScrollArea className="py-3">
-            <EditInfoDialogContent form={form} />
-          </ScrollArea>
+
+          {loading ? (
+            <div className="flex flex-col items-center justify-center w-full h-[160px]">
+              <LoadingSpinner size={50}></LoadingSpinner>
+              <p>Enviando modificações...</p>
+            </div>
+          ) : (
+            <ScrollArea className="py-3">
+              <EditInfoDialogContent form={form} />
+            </ScrollArea>
+          )}
+
           <DialogFooter
             className="px-1 sm:flex-col-reverse sm:space-x-0 
                      sm:gap-y-2 lg:flex-row lg:justify-end lg:space-x-2 
@@ -533,7 +537,7 @@ export function StudentInfoEditDialog({
             </Button>
             <Button
               type="submit"
-              disabled={Object.keys(errors).length !== 0}
+              disabled={Object.keys(errors).length !== 0 || loading}
               variant={`${Object.keys(errors).length !== 0 ? 'destructive' : 'default'}`}
             >
               Editar

--- a/src/components/student-profile/student-info-edit-dialog.tsx
+++ b/src/components/student-profile/student-info-edit-dialog.tsx
@@ -11,28 +11,20 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 
-import { ExclamationTriangleIcon } from '@radix-ui/react-icons'
 import { LoadingSpinner } from '@/components/loading-spinner'
 import { useSession } from 'next-auth/react'
-import {
-  Settings,
-  CalendarIcon,
-  Eye,
-  EyeOff,
-  MessageCircleQuestion,
-  FileDigit,
-} from 'lucide-react'
+import { Settings, CalendarIcon } from 'lucide-react'
 
 import { useState } from 'react'
 
 import { Input } from '@/components/ui/input'
 
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+// import {
+//   Tooltip,
+//   TooltipContent,
+//   TooltipProvider,
+//   TooltipTrigger,
+// } from '@/components/ui/tooltip'
 
 import {
   Select,
@@ -63,9 +55,8 @@ import { ptBR } from 'date-fns/locale'
 import { cn, formatPhone } from '@/lib/utils'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useForm } from 'react-hook-form'
+import { UseFormReturn, useForm } from 'react-hook-form'
 
-import { useRouter, useSearchParams } from 'next/navigation'
 import { z } from 'zod'
 import { StudentResponse } from './student-profile'
 import { Textarea } from '../ui/textarea'
@@ -132,101 +123,13 @@ const EditInfoSchema = z.object({
 type EditInfoSchema = z.infer<typeof EditInfoSchema>
 
 const EditInfoDialogContent = ({
-  studentData,
+  form,
 }: {
-  studentData: StudentResponse
+  form: UseFormReturn<EditInfoSchema>
 }) => {
-  const defaultFormData: EditableInfoData = {
-    about: studentData.about,
-    name: studentData.name,
-    birthDate: new Date(studentData.birthDate),
-    course:
-      studentData.course === 'COMPUTER_SCIENCE'
-        ? 'Ciência da Computação'
-        : 'Engenharia de Computação',
-    phone: studentData.phone,
-    secondaryPhone: studentData.secondaryPhone || '',
-    semester: studentData.period.toString(),
-    entrySemester: studentData.entryPeriod,
-    registration: studentData.registration,
-  }
-
-  const form = useForm<EditInfoSchema>({
-    resolver: zodResolver(EditInfoSchema),
-    defaultValues: defaultFormData,
-  })
-  // const email = useSearchParams().get('email')
-
-  // const { toast } = useToast()
-  // const { push } = useRouter()
-
-  const submitHandler = async (data: EditInfoSchema) => {
-    console.log(data)
-    // const dataToSend = formatSignUpData(data)
-
-    // // enviar os dados para a API
-
-    // const formData = new FormData()
-    // formData.append('name', dataToSend.name)
-    // formData.append('birthDate', dataToSend.birthdate)
-    // formData.append('course', dataToSend.course)
-    // formData.append('file', data.image[0])
-    // formData.append('registration', dataToSend.registration)
-    // formData.append('phone', dataToSend.phone)
-    // formData.append('secondaryPhone', dataToSend.secondaryPhone)
-    // formData.append('period', dataToSend.period)
-    // formData.append('entryPeriod', dataToSend.entryPeriod)
-    // formData.append('password', dataToSend.password)
-    // formData.append('email', email || '')
-    // formData.append('activationCode', id)
-
-    // try {
-    //   const response = await fetch('http://127.0.0.1:8080/api/v1/students', {
-    //     method: 'POST',
-    //     body: formData,
-    //   })
-
-    //   const status = response.status
-
-    //   if (response.ok) {
-    //     if (status === 201) {
-    //       toast({
-    //         title: 'Cadastro realizado com sucesso',
-    //         description: 'Seja bem vindo!',
-    //       })
-
-    //       push('/register/completed')
-    //     }
-    //   }
-
-    //   if (status >= 400 && status < 500) {
-    //     toast({
-    //       variant: 'destructive',
-    //       title: 'Erro ao fazer o cadastro',
-    //       description: 'Verifique os campos e tente novamente.',
-    //     })
-    //   }
-
-    //   if (status >= 500) {
-    //     toast({
-    //       title: 'Não foi possível fazer o cadastro',
-    //       description: 'Tente novamente mais tarde',
-    //     })
-    //   }
-    // } catch (error) {
-    //   console.error('Erro ao enviar o formulário:', error)
-    //   toast({
-    //     title: 'Erro',
-    //     description: 'Erro ao enviar os dados.',
-    //   })
-    // }
-  }
   return (
     <Form {...form}>
-      <form
-        className="w-full lg:max-w-[46rem] max-h-[60vh] p-1"
-        onSubmit={form.handleSubmit(submitHandler)}
-      >
+      <div className="w-full lg:max-w-[46rem] max-h-[60vh] p-1">
         <div className="mb-2 lg:mb-4">
           <FormField
             control={form.control}
@@ -444,9 +347,7 @@ const EditInfoDialogContent = ({
             />
           </div>
         </div>
-
-        {/* <Button className="w-full ">Cadastrar</Button> */}
-      </form>
+      </div>
     </Form>
   )
 }
@@ -466,35 +367,38 @@ function LoadingDialogContent(props: { title: string; message: string }) {
   )
 }
 
-export function StudentInformationEditDialog({
+export function StudentInfoEditDialog({
   studentData,
 }: {
   studentData: StudentResponse
 }) {
-  // const { data } = useSession()
-  // const [formData, setFormData] = useState<fromData>({
-  //   studentGroup: '',
-  //   admissionMonth: '',
-  //   admissionYear: '',
-  //   emails: '',
-  // })
   const [showDialog, setShowDialog] = useState<boolean>(false)
-  // const [validatedEmails, setValidatedEmails] = useState<
-  //   Array<{ email: string; isValid: boolean }>
-  // >([])
-  const [error, setError] = useState<boolean>(false)
-  // const [dialogState, _setDialogState] = useState<{
-  //   page: DialogPage
-  //   data: Record<string, unknown>
-  // }>({
-  //   page: DialogPage.Input,
-  //   data: {},
-  // })
+
+  const defaultFormData: EditableInfoData = {
+    about: studentData.about,
+    name: studentData.name,
+    birthDate: new Date(studentData.birthDate),
+    course:
+      studentData.course === 'COMPUTER_SCIENCE'
+        ? 'Ciência da Computação'
+        : 'Engenharia de Computação',
+    phone: studentData.phone,
+    secondaryPhone: studentData.secondaryPhone || '',
+    semester: studentData.period.toString(),
+    entrySemester: studentData.entryPeriod,
+    registration: studentData.registration,
+  }
+
+  const form = useForm<EditInfoSchema>({
+    resolver: zodResolver(EditInfoSchema),
+    defaultValues: defaultFormData,
+  })
+
+  const errors = form.formState.errors
 
   function handleDialogOpen(): void {
     // This is necessary to remove error indicators when re-opening the dialog.
     setShowDialog(true)
-    // setError(false)
   }
 
   function onShowDialogChange(): void {
@@ -503,11 +407,6 @@ export function StudentInformationEditDialog({
     // would trigger and the Dialog would never open.
     showDialog && setShowDialog(false)
   }
-
-  // function handleFormDataChange(field: string, value: string): void {
-  //   setError(false)
-  //   setFormData((prevState) => ({ ...prevState, [field]: value }))
-  // }
 
   // async function handleConfirm() {
   //   // Set loading state
@@ -558,6 +457,68 @@ export function StudentInformationEditDialog({
   //   }
   // }
 
+  const submitHandler = async (data: EditInfoSchema) => {
+    console.log(data)
+    // const dataToSend = formatSignUpData(data)
+
+    // // enviar os dados para a API
+
+    // const formData = new FormData()
+    // formData.append('name', dataToSend.name)
+    // formData.append('birthDate', dataToSend.birthdate)
+    // formData.append('course', dataToSend.course)
+    // formData.append('file', data.image[0])
+    // formData.append('registration', dataToSend.registration)
+    // formData.append('phone', dataToSend.phone)
+    // formData.append('secondaryPhone', dataToSend.secondaryPhone)
+    // formData.append('period', dataToSend.period)
+    // formData.append('entryPeriod', dataToSend.entryPeriod)
+    // formData.append('password', dataToSend.password)
+    // formData.append('email', email || '')
+    // formData.append('activationCode', id)
+
+    // try {
+    //   const response = await fetch('http://127.0.0.1:8080/api/v1/students', {
+    //     method: 'POST',
+    //     body: formData,
+    //   })
+
+    //   const status = response.status
+
+    //   if (response.ok) {
+    //     if (status === 201) {
+    //       toast({
+    //         title: 'Cadastro realizado com sucesso',
+    //         description: 'Seja bem vindo!',
+    //       })
+
+    //       push('/register/completed')
+    //     }
+    //   }
+
+    //   if (status >= 400 && status < 500) {
+    //     toast({
+    //       variant: 'destructive',
+    //       title: 'Erro ao fazer o cadastro',
+    //       description: 'Verifique os campos e tente novamente.',
+    //     })
+    //   }
+
+    //   if (status >= 500) {
+    //     toast({
+    //       title: 'Não foi possível fazer o cadastro',
+    //       description: 'Tente novamente mais tarde',
+    //     })
+    //   }
+    // } catch (error) {
+    //   console.error('Erro ao enviar o formulário:', error)
+    //   toast({
+    //     title: 'Erro',
+    //     description: 'Erro ao enviar os dados.',
+    //   })
+    // }
+  }
+
   return (
     <Dialog open={showDialog} onOpenChange={onShowDialogChange}>
       <DialogTrigger asChild>
@@ -566,33 +527,40 @@ export function StudentInformationEditDialog({
         </Button>
       </DialogTrigger>
       <DialogContent className="lg:max-w-[46rem]">
-        <DialogHeader className="px-1">
-          <DialogTitle>Editar informações básicas</DialogTitle>
-          <DialogDescription>
-            Atualize seu texto de apresentação, dados acadêmicos e outras
-            informações pessoais para manter seu perfil correto e atualizado.
-          </DialogDescription>
-        </DialogHeader>
-        <ScrollArea className="h-full">
-          <EditInfoDialogContent studentData={studentData} />
-        </ScrollArea>
-        <DialogFooter className="px-1 sm:flex-col-reverse sm:space-x-0 sm:gap-y-2 lg:flex-row lg:justify-end lg:space-x-2 lg:gap-y-0">
-          <Button
-            type="button"
-            variant="secondary"
-            // onClick={props.handleFinalize}
+        <form onSubmit={form.handleSubmit(submitHandler)}>
+          <DialogHeader className="px-1">
+            <DialogTitle>Editar informações básicas</DialogTitle>
+            <DialogDescription>
+              Atualize seu texto de apresentação, dados acadêmicos e outras
+              informações pessoais para manter seu perfil correto e atualizado.
+            </DialogDescription>
+          </DialogHeader>
+          <ScrollArea className="py-3">
+            <EditInfoDialogContent form={form} />
+          </ScrollArea>
+          <DialogFooter
+            className="px-1 sm:flex-col-reverse sm:space-x-0 
+                     sm:gap-y-2 lg:flex-row lg:justify-end lg:space-x-2 
+                     lg:gap-y-0"
           >
-            Cancelar
-          </Button>
-          <Button
-            type="submit"
-            // onClick={props.handleSubmit}
-            disabled={error}
-            variant={`${error ? 'destructive' : 'default'}`}
-          >
-            Editar
-          </Button>
-        </DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                setShowDialog(false)
+              }}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={Object.keys(errors).length !== 0}
+              variant={`${Object.keys(errors).length !== 0 ? 'destructive' : 'default'}`}
+            >
+              Editar
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   )

--- a/src/components/student-profile/student-info-edit-dialog.tsx
+++ b/src/components/student-profile/student-info-edit-dialog.tsx
@@ -1,0 +1,578 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+
+import { ExclamationTriangleIcon } from '@radix-ui/react-icons'
+import { LoadingSpinner } from '@/components/loading-spinner'
+import { useSession } from 'next-auth/react'
+import {
+  Settings,
+  CalendarIcon,
+  Eye,
+  EyeOff,
+  MessageCircleQuestion,
+} from 'lucide-react'
+
+import { useState } from 'react'
+
+import { Input } from '@/components/ui/input'
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+
+import { Calendar } from '@/components/ui/calendar'
+import { format } from 'date-fns'
+import { ptBR } from 'date-fns/locale'
+import { cn, formatPhone } from '@/lib/utils'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { z } from 'zod'
+import { StudentResponse } from './student-profile'
+
+interface EditableInfoData {
+  about: string | ''
+  name: string
+  birthDate: Date
+  course: 'Ciência da Computação' | 'Engenharia de Computação'
+  phone: string
+  secondaryPhone: string | ''
+  semester: string
+  entrySemester: string
+  registration: string
+}
+
+const EditInfoSchema = z.object({
+  about: z
+    .string()
+    .max(1000, 'Limite seu texto a 1000 caracteres')
+    .optional()
+    .or(z.literal('')),
+  name: z
+    .string()
+    .min(3, 'Preencha com seu nome completo.')
+    .max(30, 'Limite de 30 caracteres atingido')
+    .regex(
+      /^[a-zA-Z\sáéíóúãáçÃÁÉÍÓÚ]+$/,
+      'O nome deve conter apenas letras A-Z a-z, espaços e acentos.',
+    ),
+  birthDate: z.date(),
+  course: z.enum(['Ciência da Computação', 'Engenharia de Computação']),
+  phone: z
+    .string()
+    .min(10, 'Número de telefone inválido.')
+    .max(15, 'Número de telefone inválido.'),
+  secondaryPhone: z
+    .string()
+    .min(10, 'Número de telefone inválido.')
+    .max(15, 'Número de telefone inválido.')
+    .optional()
+    .or(z.literal('')),
+  semester: z.coerce
+    .string()
+    .min(1, 'Semestre Inválido.')
+    .max(10, 'Semestre Inválido.'),
+  entrySemester: z.string().refine(
+    (value) => {
+      const currentYear = new Date().getFullYear()
+      const entryYear = parseInt(value.split('.')[0], 10)
+      return /^\d{4}\.(1|2)$/.test(value) && entryYear <= currentYear
+    },
+    {
+      message:
+        'O ano do período de ingresso não pode ser posterior ao ano atual e deve estar no formato ANO.SEMESTRE_LETIVO (ex: 2020.1, 2020.2, 2024.1, 2024.2)',
+    },
+  ),
+  registration: z.string().refine((value) => /^\d{8}$/.test(value), {
+    message: 'Formato de matrícula inválido',
+  }),
+})
+
+type EditInfoSchema = z.infer<typeof EditInfoSchema>
+
+const EditInfoDialogContent = ({
+  studentData,
+}: {
+  studentData: StudentResponse
+}) => {
+  const defaultFormData: EditableInfoData = {
+    about: studentData.about,
+    name: studentData.name,
+    birthDate: new Date(studentData.birthDate),
+    course:
+      studentData.course === 'COMPUTER_SCIENCE'
+        ? 'Ciência da Computação'
+        : 'Engenharia de Computação',
+    phone: studentData.phone,
+    secondaryPhone: studentData.secondaryPhone || '',
+    semester: studentData.period.toString(),
+    entrySemester: studentData.entryPeriod,
+    registration: studentData.registration,
+  }
+
+  const form = useForm<EditInfoSchema>({
+    resolver: zodResolver(EditInfoSchema),
+    defaultValues: defaultFormData,
+  })
+  // const email = useSearchParams().get('email')
+
+  // const { toast } = useToast()
+  // const { push } = useRouter()
+
+  const submitHandler = async (data: EditInfoSchema) => {
+    console.log(data)
+    // const dataToSend = formatSignUpData(data)
+
+    // // enviar os dados para a API
+
+    // const formData = new FormData()
+    // formData.append('name', dataToSend.name)
+    // formData.append('birthDate', dataToSend.birthdate)
+    // formData.append('course', dataToSend.course)
+    // formData.append('file', data.image[0])
+    // formData.append('registration', dataToSend.registration)
+    // formData.append('phone', dataToSend.phone)
+    // formData.append('secondaryPhone', dataToSend.secondaryPhone)
+    // formData.append('period', dataToSend.period)
+    // formData.append('entryPeriod', dataToSend.entryPeriod)
+    // formData.append('password', dataToSend.password)
+    // formData.append('email', email || '')
+    // formData.append('activationCode', id)
+
+    // try {
+    //   const response = await fetch('http://127.0.0.1:8080/api/v1/students', {
+    //     method: 'POST',
+    //     body: formData,
+    //   })
+
+    //   const status = response.status
+
+    //   if (response.ok) {
+    //     if (status === 201) {
+    //       toast({
+    //         title: 'Cadastro realizado com sucesso',
+    //         description: 'Seja bem vindo!',
+    //       })
+
+    //       push('/register/completed')
+    //     }
+    //   }
+
+    //   if (status >= 400 && status < 500) {
+    //     toast({
+    //       variant: 'destructive',
+    //       title: 'Erro ao fazer o cadastro',
+    //       description: 'Verifique os campos e tente novamente.',
+    //     })
+    //   }
+
+    //   if (status >= 500) {
+    //     toast({
+    //       title: 'Não foi possível fazer o cadastro',
+    //       description: 'Tente novamente mais tarde',
+    //     })
+    //   }
+    // } catch (error) {
+    //   console.error('Erro ao enviar o formulário:', error)
+    //   toast({
+    //     title: 'Erro',
+    //     description: 'Erro ao enviar os dados.',
+    //   })
+    // }
+  }
+  return (
+    <Form {...form}>
+      <form
+        className="w-full lg:max-w-[46rem]"
+        onSubmit={form.handleSubmit(submitHandler)}
+      >
+        <div className="lg:grid lg:grid-cols-2 gap-5">
+          <div>
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nome Completo</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div>
+            <FormField
+              control={form.control}
+              name="course"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Curso</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Selecione o seu curso" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="Ciência da Computação">
+                        Ciência da Computação
+                      </SelectItem>
+                      <SelectItem value="Engenharia de Computação">
+                        Engenharia de Computação
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div>
+            <FormField
+              control={form.control}
+              name="birthDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Data de Nascimento</FormLabel>
+                  <FormControl>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant={'outline'}
+                          className={cn(
+                            'pl-3 text-left font-normal w-full',
+                            !field.value && 'text-muted-foreground',
+                          )}
+                        >
+                          {field.value ? (
+                            format(field.value, 'PPP')
+                          ) : (
+                            <span>Selecione um data</span>
+                          )}
+                          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0" align="start">
+                        <Calendar
+                          locale={ptBR}
+                          defaultMonth={field.value}
+                          mode="single"
+                          selected={field.value}
+                          onSelect={field.onChange}
+                          disabled={(date) =>
+                            date > new Date() || date < new Date('1900-01-01')
+                          }
+                          // initialFocus
+                        />
+                      </PopoverContent>
+                    </Popover>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div>
+            <FormField
+              control={form.control}
+              name="registration"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Número de Matrícula</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div>
+            <FormField
+              control={form.control}
+              name="phone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Telefone</FormLabel>
+                  <FormControl>
+                    <Input
+                      defaultValue={formatPhone(field.value)}
+                      onChange={field.onChange}
+                      placeholder="(99) 9999-9999"
+                      pattern="(\([0-9]{2}\))\s([9]{1})([0-9]{4})-([0-9]{4})"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div>
+            <FormField
+              control={form.control}
+              name="semester"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Período Atual</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Selecione o seu período" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="1">1</SelectItem>
+                      <SelectItem value="2">2</SelectItem>
+                      <SelectItem value="3">3</SelectItem>
+                      <SelectItem value="4">4</SelectItem>
+                      <SelectItem value="5">5</SelectItem>
+                      <SelectItem value="6">6</SelectItem>
+                      <SelectItem value="7">7</SelectItem>
+                      <SelectItem value="8">8</SelectItem>
+                      <SelectItem value="9">9</SelectItem>
+                      <SelectItem value="10">10</SelectItem>
+                      <SelectItem value="11">11</SelectItem>
+                      <SelectItem value="12">12</SelectItem>
+                      <SelectItem value="13">13</SelectItem>
+                      <SelectItem value="14">14</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div>
+            <FormField
+              control={form.control}
+              name="secondaryPhone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Telefone Secundário</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="(99) 9999-9999"
+                      pattern="(\([0-9]{2}\))\s([9]{1})([0-9]{4})-([0-9]{4})"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div>
+            <FormField
+              control={form.control}
+              name="entrySemester"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Ano Letivo de Ingreeso</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="Ex: 2021.1, 2023.2" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </div>
+
+        {/* <Button className="w-full ">Cadastrar</Button> */}
+      </form>
+    </Form>
+  )
+}
+
+function LoadingDialogContent(props: { title: string; message: string }) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{props.title}</DialogTitle>
+        <DialogDescription>{props.message}</DialogDescription>
+      </DialogHeader>
+      <div className="flex flex-col items-center justify-center w-full h-[160px]">
+        <LoadingSpinner size={50}></LoadingSpinner>
+        <p>Carregando...</p>
+      </div>
+    </>
+  )
+}
+
+export function StudentInformationEditDialog({
+  studentData,
+}: {
+  studentData: StudentResponse
+}) {
+  // const { data } = useSession()
+  // const [formData, setFormData] = useState<fromData>({
+  //   studentGroup: '',
+  //   admissionMonth: '',
+  //   admissionYear: '',
+  //   emails: '',
+  // })
+  const [showDialog, setShowDialog] = useState<boolean>(false)
+  // const [validatedEmails, setValidatedEmails] = useState<
+  //   Array<{ email: string; isValid: boolean }>
+  // >([])
+  const [error, setError] = useState<boolean>(false)
+  // const [dialogState, _setDialogState] = useState<{
+  //   page: DialogPage
+  //   data: Record<string, unknown>
+  // }>({
+  //   page: DialogPage.Input,
+  //   data: {},
+  // })
+
+  function handleDialogOpen(): void {
+    // This is necessary to remove error indicators when re-opening the dialog.
+    setShowDialog(true)
+    // setError(false)
+  }
+
+  function onShowDialogChange(): void {
+    // This is necessary, because when the Dialog is closed showDialog
+    // is false. So, everytime showDialog tried to change to true, this
+    // would trigger and the Dialog would never open.
+    showDialog && setShowDialog(false)
+  }
+
+  // function handleFormDataChange(field: string, value: string): void {
+  //   setError(false)
+  //   setFormData((prevState) => ({ ...prevState, [field]: value }))
+  // }
+
+  // async function handleConfirm() {
+  //   // Set loading state
+  //   setDialogState(DialogPage.Loading, {
+  //     title: 'Enviando convites.',
+  //     message:
+  //       'Os convites estão sendo enviados para os alunos. Por favor, aguarde.',
+  //   })
+
+  //   // prepare data
+  //   const requestData = {
+  //     emails: validatedEmails.map((email) => email.email),
+  //     entryDate: `${formData.admissionYear}-${formData.admissionMonth.padStart(2, '0')}-01`,
+  //     studentGroup: Number(formData.studentGroup),
+  //   }
+
+  //   // Get logged user credentials
+  //   const token = (data as UserSession).user.authToken
+
+  //   const res = await fetch(`${process.env.backendRoute}/api/v1/register`, {
+  //     method: 'POST',
+  //     headers: {
+  //       'Content-Type': 'application/json',
+  //       Authorization: `Bearer ${token}`,
+  //     },
+  //     body: JSON.stringify(requestData),
+  //   })
+
+  //   // Validate response and show appropriate response dialog
+  //   if (res.ok) {
+  //     const data: BackendResponse = (await res.json()) as BackendResponse
+
+  //     if (data.failedEmails.length === 0) {
+  //       setDialogState(DialogPage.BackendResponse, {
+  //         typeOfResponse: BackendResponseType.Success,
+  //       })
+  //     } else {
+  //       setDialogState(DialogPage.BackendResponse, {
+  //         typeOfResponse: BackendResponseType.InvitationSendingError,
+  //         invalidEmails: data.failedEmails,
+  //       })
+  //     }
+  //   } else {
+  //     setDialogState(DialogPage.BackendResponse, {
+  //       typeOfResponse: BackendResponseType.AnotherError,
+  //       responseCode: res.status,
+  //     })
+  //   }
+  // }
+
+  return (
+    <Dialog open={showDialog} onOpenChange={onShowDialogChange}>
+      <DialogTrigger asChild>
+        <Button variant="secondary" onClick={handleDialogOpen}>
+          <Settings />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="lg:max-w-[46rem]">
+        <DialogHeader>
+          <DialogTitle>Editar informações básicas</DialogTitle>
+          <DialogDescription>
+            Atualize seu texto de apresentação, dados acadêmicos e outras
+            informações pessoais para manter seu perfil correto e atualizado.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <EditInfoDialogContent studentData={studentData} />
+        </div>
+        <DialogFooter className="sm:flex-col-reverse sm:space-x-0 sm:gap-y-2 lg:flex-row lg:justify-end lg:space-x-2 lg:gap-y-0">
+          <Button
+            type="button"
+            variant="secondary"
+            // onClick={props.handleFinalize}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="submit"
+            // onClick={props.handleSubmit}
+            disabled={error}
+            variant={`${error ? 'destructive' : 'default'}`}
+          >
+            Editar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/student-profile/student-info-edit-dialog.tsx
+++ b/src/components/student-profile/student-info-edit-dialog.tsx
@@ -102,16 +102,16 @@ const EditInfoSchema = z.object({
     .min(10, 'Número de telefone inválido.')
     .max(15, 'Número de telefone inválido.')
     .regex(
-      /^(\([0-9]{2}\))\s?([9]?)([0-9]{4})-([0-9]{4})$/,
-      'Números de telefone válidos são da forma (XX) 9XXXX-XXXX ou (XX) XXXX-XXXX',
+      /^(\([0-9]{2}\))\s?([9]{1})([0-9]{4})-([0-9]{4})$/,
+      'Números de telefone válidos são da forma (XX) 9XXXX-XXXX',
     ),
   secondaryPhone: z
     .string()
     .min(10, 'Número de telefone inválido.')
     .max(15, 'Número de telefone inválido.')
     .regex(
-      /^(\([0-9]{2}\))\s?([9]?)([0-9]{4})-([0-9]{4})$/,
-      'Números de telefone válidos são da forma (XX) 9XXXX-XXXX ou (XX) XXXX-XXXX',
+      /^(\([0-9]{2}\))\s?([9]{1})([0-9]{4})-([0-9]{4})$/,
+      'Números de telefone válidos são da forma (XX) 9XXXX-XXXX',
     )
     .optional()
     .or(z.literal('')),

--- a/src/components/student-profile/student-info-edit-dialog.tsx
+++ b/src/components/student-profile/student-info-edit-dialog.tsx
@@ -20,6 +20,7 @@ import {
   Eye,
   EyeOff,
   MessageCircleQuestion,
+  FileDigit,
 } from 'lucide-react'
 
 import { useState } from 'react'
@@ -67,6 +68,8 @@ import { useForm } from 'react-hook-form'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { z } from 'zod'
 import { StudentResponse } from './student-profile'
+import { Textarea } from '../ui/textarea'
+import { ScrollArea } from '../ui/scroll-area'
 
 interface EditableInfoData {
   about: string | ''
@@ -221,10 +224,28 @@ const EditInfoDialogContent = ({
   return (
     <Form {...form}>
       <form
-        className="w-full lg:max-w-[46rem]"
+        className="w-full lg:max-w-[46rem] max-h-[60vh] p-1"
         onSubmit={form.handleSubmit(submitHandler)}
       >
-        <div className="lg:grid lg:grid-cols-2 gap-5">
+        <div className="mb-2 lg:mb-4">
+          <FormField
+            control={form.control}
+            name="about"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Sobre mim</FormLabel>
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    className="resize-none h-[80px] lg:h-[110px]"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <div className="lg:grid lg:grid-cols-2 lg:gap-4 gap-8">
           <div>
             <FormField
               control={form.control}
@@ -545,17 +566,17 @@ export function StudentInformationEditDialog({
         </Button>
       </DialogTrigger>
       <DialogContent className="lg:max-w-[46rem]">
-        <DialogHeader>
+        <DialogHeader className="px-1">
           <DialogTitle>Editar informações básicas</DialogTitle>
           <DialogDescription>
             Atualize seu texto de apresentação, dados acadêmicos e outras
             informações pessoais para manter seu perfil correto e atualizado.
           </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 py-4">
+        <ScrollArea className="h-full">
           <EditInfoDialogContent studentData={studentData} />
-        </div>
-        <DialogFooter className="sm:flex-col-reverse sm:space-x-0 sm:gap-y-2 lg:flex-row lg:justify-end lg:space-x-2 lg:gap-y-0">
+        </ScrollArea>
+        <DialogFooter className="px-1 sm:flex-col-reverse sm:space-x-0 sm:gap-y-2 lg:flex-row lg:justify-end lg:space-x-2 lg:gap-y-0">
           <Button
             type="button"
             variant="secondary"

--- a/src/components/student-profile/student-info-edit-dialog.tsx
+++ b/src/components/student-profile/student-info-edit-dialog.tsx
@@ -85,7 +85,7 @@ const EditInfoSchema = z.object({
     .min(3, 'Preencha com seu nome completo.')
     .max(30, 'Limite de 30 caracteres atingido')
     .regex(
-      /^[a-zA-Z\sáéíóúãáçÃÁÉÍÓÚ]+$/,
+      /^[a-zA-Z\sáéêíóúãáçÃÁÉÊÍÓÚ]+$/,
       'O nome deve conter apenas letras A-Z a-z, espaços e acentos.',
     ),
   birthDate: z.date(),
@@ -93,11 +93,19 @@ const EditInfoSchema = z.object({
   phone: z
     .string()
     .min(10, 'Número de telefone inválido.')
-    .max(15, 'Número de telefone inválido.'),
+    .max(15, 'Número de telefone inválido.')
+    .regex(
+      /^(\([0-9]{2}\))\s?([9]?)([0-9]{4})-([0-9]{4})$/,
+      'Números de telefone válidos são da forma (XX) 9XXXX-XXXX ou (XX) XXXX-XXXX',
+    ),
   secondaryPhone: z
     .string()
     .min(10, 'Número de telefone inválido.')
     .max(15, 'Número de telefone inválido.')
+    .regex(
+      /^(\([0-9]{2}\))\s?([9]?)([0-9]{4})-([0-9]{4})$/,
+      'Números de telefone válidos são da forma (XX) 9XXXX-XXXX ou (XX) XXXX-XXXX',
+    )
     .optional()
     .or(z.literal('')),
   semester: z.coerce
@@ -265,10 +273,9 @@ const EditInfoDialogContent = ({
                   <FormLabel>Telefone</FormLabel>
                   <FormControl>
                     <Input
-                      defaultValue={formatPhone(field.value)}
+                      defaultValue={field.value}
                       onChange={field.onChange}
-                      placeholder="(99) 9999-9999"
-                      pattern="(\([0-9]{2}\))\s([9]{1})([0-9]{4})-([0-9]{4})"
+                      placeholder="(99) 99999-9999"
                     />
                   </FormControl>
                   <FormMessage />
@@ -323,9 +330,9 @@ const EditInfoDialogContent = ({
                   <FormLabel>Telefone Secundário</FormLabel>
                   <FormControl>
                     <Input
-                      {...field}
-                      placeholder="(99) 9999-9999"
-                      pattern="(\([0-9]{2}\))\s([9]{1})([0-9]{4})-([0-9]{4})"
+                      defaultValue={field.value}
+                      onChange={field.onChange}
+                      placeholder="(99) 99999-9999"
                     />
                   </FormControl>
                   <FormMessage />
@@ -384,8 +391,8 @@ export function StudentInfoEditDialog({
       studentData.course === 'COMPUTER_SCIENCE'
         ? 'Ciência da Computação'
         : 'Engenharia de Computação',
-    phone: studentData.phone,
-    secondaryPhone: studentData.secondaryPhone || '',
+    phone: formatPhone(studentData.phone),
+    secondaryPhone: formatPhone(studentData.secondaryPhone || ''),
     semester: studentData.period.toString(),
     entrySemester: studentData.entryPeriod,
     registration: studentData.registration,

--- a/src/components/student-profile/student-profile.tsx
+++ b/src/components/student-profile/student-profile.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react'
 import InfoBox from './info-box'
 import { enumToStringCourse } from '@/lib/utils'
 import { StudentInfoEditDialog } from './student-info-edit-dialog'
-
+import { LoadingSpinner } from '../loading-spinner'
 export interface StudentResponse {
   name: string
   photoUrl: string
@@ -52,7 +52,13 @@ const StudentProfile = ({ username }: { username: string }) => {
     fetchStudentData()
   }, [username, data])
 
-  if (isLoading) return <div>Carregando...</div>
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-[50vh]">
+        <LoadingSpinner size={70}></LoadingSpinner>
+      </div>
+    )
+  }
   if (!studentData) return <div>Erro ao carregar dados...</div>
 
   return (

--- a/src/components/student-profile/student-profile.tsx
+++ b/src/components/student-profile/student-profile.tsx
@@ -3,7 +3,7 @@ import { UserSession } from '@/lib/auth'
 import { useSession } from 'next-auth/react'
 import { useEffect, useState } from 'react'
 import InfoBox from './info-box'
-import { enumToStringCourse } from '@/lib/utils'
+import { enumToStringCourse, getUsername } from '@/lib/utils'
 import { StudentInformationEditDialog } from './student-info-edit-dialog'
 
 export interface StudentResponse {
@@ -60,13 +60,9 @@ const StudentProfile = ({ username }: { username: string }) => {
       <div className="flex flex-row justify-between">
         <div className="flex justify-between w-full">
           <h2 className="text-2xl font-bold">Informações básicas</h2>
-          <StudentInformationEditDialog studentData={studentData} />
         </div>
         {studentData.email === data?.user?.email ? (
-          // TODO: change button to icon
-          <button className="bg-black text-white px-2 py-1 rounded-sm mt-2">
-            Editar
-          </button>
+          <StudentInformationEditDialog studentData={studentData} />
         ) : null}
       </div>
       <div className="flex flex-row gap-5 p-6 rounded-sm shadow-lg border mt-2">

--- a/src/components/student-profile/student-profile.tsx
+++ b/src/components/student-profile/student-profile.tsx
@@ -3,8 +3,8 @@ import { UserSession } from '@/lib/auth'
 import { useSession } from 'next-auth/react'
 import { useEffect, useState } from 'react'
 import InfoBox from './info-box'
-import { enumToStringCourse, getUsername } from '@/lib/utils'
-import { StudentInformationEditDialog } from './student-info-edit-dialog'
+import { enumToStringCourse } from '@/lib/utils'
+import { StudentInfoEditDialog } from './student-info-edit-dialog'
 
 export interface StudentResponse {
   name: string
@@ -62,7 +62,7 @@ const StudentProfile = ({ username }: { username: string }) => {
           <h2 className="text-2xl font-bold">Informações básicas</h2>
         </div>
         {studentData.email === data?.user?.email ? (
-          <StudentInformationEditDialog studentData={studentData} />
+          <StudentInfoEditDialog studentData={studentData} />
         ) : null}
       </div>
       <div className="flex flex-row gap-5 p-6 rounded-sm shadow-lg border mt-2">

--- a/src/components/student-profile/student-profile.tsx
+++ b/src/components/student-profile/student-profile.tsx
@@ -4,8 +4,9 @@ import { useSession } from 'next-auth/react'
 import { useEffect, useState } from 'react'
 import InfoBox from './info-box'
 import { enumToStringCourse } from '@/lib/utils'
+import { StudentInformationEditDialog } from './student-info-edit-dialog'
 
-interface StudentResponse {
+export interface StudentResponse {
   name: string
   photoUrl: string
   birthDate: string
@@ -57,7 +58,10 @@ const StudentProfile = ({ username }: { username: string }) => {
   return (
     <div className="w-screen max-w-[90%] mx-4 mt-9">
       <div className="flex flex-row justify-between">
-        <h2 className="text-2xl font-bold">Informações básicas</h2>
+        <div className="flex justify-between w-full">
+          <h2 className="text-2xl font-bold">Informações básicas</h2>
+          <StudentInformationEditDialog studentData={studentData} />
+        </div>
         {studentData.email === data?.user?.email ? (
           // TODO: change button to icon
           <button className="bg-black text-white px-2 py-1 rounded-sm mt-2">

--- a/src/components/student-profile/student-profile.tsx
+++ b/src/components/student-profile/student-profile.tsx
@@ -62,7 +62,10 @@ const StudentProfile = ({ username }: { username: string }) => {
           <h2 className="text-2xl font-bold">Informações básicas</h2>
         </div>
         {studentData.email === data?.user?.email ? (
-          <StudentInfoEditDialog studentData={studentData} />
+          <StudentInfoEditDialog
+            studentData={studentData}
+            setStudentData={setStudentData}
+          />
         ) : null}
       </div>
       <div className="flex flex-row gap-5 p-6 rounded-sm shadow-lg border mt-2">

--- a/src/components/ui/calendar-with-dropdowns.tsx
+++ b/src/components/ui/calendar-with-dropdowns.tsx
@@ -1,0 +1,110 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* Referêcia: https://gist.github.com/mjbalcueva/1fbcb1be9ef68a82c14d778b686a04fa */
+'use client'
+
+import * as React from 'react'
+import { buttonVariants } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { DayPicker, DropdownProps } from 'react-day-picker'
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>
+
+function CalendarWithDropdowns({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn('p-3', className)}
+      classNames={{
+        months: 'flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0',
+        month: 'space-y-4',
+        caption: 'flex justify-center pt-1 relative items-center',
+        caption_label: 'text-sm font-medium',
+        caption_dropdowns: 'flex justify-center gap-1',
+        nav: 'space-x-1 flex items-center',
+        nav_button: cn(
+          buttonVariants({ variant: 'outline' }),
+          'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
+        ),
+        nav_button_previous: 'absolute left-1',
+        nav_button_next: 'absolute right-1',
+        table: 'w-full border-collapse space-y-1',
+        head_row: 'flex',
+        head_cell:
+          'text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]',
+        row: 'flex w-full mt-2',
+        cell: 'text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
+        day: cn(
+          buttonVariants({ variant: 'ghost' }),
+          'h-9 w-9 p-0 font-normal aria-selected:opacity-100',
+        ),
+        day_selected:
+          'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+        day_today: 'bg-accent text-accent-foreground',
+        day_outside: 'text-muted-foreground opacity-50',
+        day_disabled: 'text-muted-foreground opacity-50',
+        day_range_middle:
+          'aria-selected:bg-accent aria-selected:text-accent-foreground',
+        day_hidden: 'invisible',
+        ...classNames,
+      }}
+      components={{
+        Dropdown: ({ value, onChange, children, ...props }: DropdownProps) => {
+          const options = React.Children.toArray(
+            children,
+          ) as React.ReactElement<React.HTMLProps<HTMLOptionElement>>[]
+          const selected = options.find((child) => child.props.value === value)
+          const handleChange = (value: string) => {
+            const changeEvent = {
+              target: { value },
+            } as React.ChangeEvent<HTMLSelectElement>
+            onChange?.(changeEvent)
+          }
+          return (
+            <Select
+              value={value?.toString()}
+              onValueChange={(value) => {
+                handleChange(value)
+              }}
+            >
+              <SelectTrigger className="pr-1.5 focus:ring-0">
+                <SelectValue>{selected?.props?.children}</SelectValue>
+              </SelectTrigger>
+              <SelectContent position="popper">
+                <ScrollArea className="h-80">
+                  {options.map((option, id: number) => (
+                    <SelectItem
+                      key={`${option.props.value}-${id}`}
+                      value={option.props.value?.toString() ?? ''}
+                    >
+                      {option.props.children}
+                    </SelectItem>
+                  ))}
+                </ScrollArea>
+              </SelectContent>
+            </Select>
+          )
+        },
+        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
+        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+      }}
+      {...props}
+    />
+  )
+}
+CalendarWithDropdowns.displayName = 'Calendar'
+
+export { CalendarWithDropdowns }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -34,6 +34,16 @@ export function getUsername(email: string) {
   return email.split('@')[0]
 }
 
-export function formatPhone(phone: string) {
-  return `(${phone.slice(0, 2)}) ${phone.slice(2, 7)}-${phone.slice(7, 11)}`
+// TODO: Make it work with both 8 digit numbers and 9 digit numbers
+export function formatPhone(phone: string): string {
+  if (phone === '') {
+    return ''
+  }
+  if (phone.length === 11) {
+    return `(${phone.slice(0, 2)}) ${phone.slice(2, 7)}-${phone.slice(7, 11)}`
+  }
+
+  if (phone.length === 10) {
+    return `(${phone.slice(0, 2)}) ${phone.slice(2, 6)}-${phone.slice(6, 10)}`
+  }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -46,4 +46,6 @@ export function formatPhone(phone: string): string {
   if (phone.length === 10) {
     return `(${phone.slice(0, 2)}) ${phone.slice(2, 6)}-${phone.slice(6, 10)}`
   }
+
+  return phone
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,3 +33,7 @@ export function enumToStringCourse(course: string) {
 export function getUsername(email: string) {
   return email.split('@')[0]
 }
+
+export function formatPhone(phone: string) {
+  return `(${phone.slice(0, 2)}) ${phone.slice(2, 7)}-${phone.slice(7, 11)}`
+}


### PR DESCRIPTION
## Introdução
Essa PR visa introduzir o modal de edição de dados pessoais do aluno, descrito pela história [EDGGA-14](https://edgebr.atlassian.net/browse/EDGGA-14).

## Mudanças visuais
Modifiquei o botão de acionamento do modal, como visto abaixo.
![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/31834336/c299a2a3-b3ce-4644-aa04-f59fd420ab4d)

O modal em si tem estrutura similar ao forms de registro de aluno, o que muda é não ter os campos de senha e ter o sobre mim.
![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/31834336/250fe158-fc0e-430a-906a-1312074977fc)

![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/31834336/735fbe8d-1fb7-4eeb-8b8d-ee4bd507a9ea)

Modifiquei o componente de calendário para incluri a seleção de meses e anos num dropdown. Me baseei no seguinte gist: https://gist.github.com/mjbalcueva/1fbcb1be9ef68a82c14d778b686a04fa. Como eu criei outro componente, essa mudança não vai quebrar a página de registro.
![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/31834336/47dc8455-c911-4e5d-a6d5-e00f97a1bc01)

Também possui um estado de loading.
![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/31834336/ac0884a9-c66e-4856-abe7-89b0a2f75ff7)

Basicamente copiei a validação que tinha sido feita no formulário de registro. 
![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/31834336/82bb8165-4cd3-47f3-a099-c2363b6f57fc)

