### PR TITLE
Feat: Página de histórico acadêmico de alunos e seus componentes

### DIFF
--- a/src/app/(dashboard)/alunos/[username]/historico/page.tsx
+++ b/src/app/(dashboard)/alunos/[username]/historico/page.tsx
@@ -21,7 +21,7 @@ const getData = async (email: string) => {
           Authorization: `Bearer ${token}`,
         },
         next: {
-          revalidate: 15,
+          revalidate: 0,
         },
       },
     )

--- a/src/app/(dashboard)/alunos/[username]/historico/page.tsx
+++ b/src/app/(dashboard)/alunos/[username]/historico/page.tsx
@@ -62,7 +62,8 @@ const StudentCollegeRecordPage = async ({ params }: { params: { username: string
   if (!studentData) {
     throw new Error('Erro ao buscar os dados')
   }
-
+  
+  // a URL do PDF ficará nula caso o PDF esteja inacessível no S3
   const pdfSrc = await checkPdfIsValid(studentData.academicRecordUrl) ? `${process.env.awsUrl}/${process.env.awsBucket}/${studentData.academicRecordUrl}` : '' 
   
   

--- a/src/app/(dashboard)/alunos/[username]/historico/page.tsx
+++ b/src/app/(dashboard)/alunos/[username]/historico/page.tsx
@@ -4,9 +4,8 @@
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import React from 'react'
-import StudentRecordFallback from '@/components/student-record/student-record-fallback'
 import StudentRecord from '@/components/student-record/student-record'
-import StudentRecordDialog from '@/components/student-record/student-record-dialog'
+
 
 const getData = async (email: string) => {
   const session = await getServerSession(authOptions)
@@ -45,22 +44,7 @@ const StudentCollegeRecordPage = async ({ params }: { params: { username: string
 
 	const pdfSrc = `${process.env.awsUrl}/${process.env.awsBucket}/${studentData.academicRecordUrl}`;
 	
-  return (
-    <div className='flex justify-center'>
-      <div className='max-w-[90vw] w-full flex flex-col px-10 py-5 h-full justify-center'>
-        <div className="flex flex-row justify-between my-5">
-          <h2 className="text-2xl font-bold">Histórico do Aluno</h2>
-          <StudentRecordDialog />
-        </div>
-        <div className='w-full h-full flex flex-col items-center'>
-          { studentData.academicRecordUrl ? 
-            ( <StudentRecord pdfSrc={ pdfSrc }/>) :
-            ( <StudentRecordFallback /> )
-          }
-        </div>
-      </div>
-    </div>   	
-  )
+  return <StudentRecord studentData={studentData} pdfSrc={pdfSrc} />
 }
 
 export default StudentCollegeRecordPage

--- a/src/app/(dashboard)/alunos/[username]/historico/page.tsx
+++ b/src/app/(dashboard)/alunos/[username]/historico/page.tsx
@@ -1,0 +1,57 @@
+'use server'
+
+import { getServerSession } from 'next-auth'
+import { useSession } from 'next-auth/react'
+import { authOptions } from '@/lib/auth'
+import React from 'react'
+import StudentRecordFallback from '@/components/student-record/student-record-fallback'
+import StudentRecord from '@/components/student-record/student-record'
+
+const getData = async (email: string) => {
+  const session = await getServerSession(authOptions)
+  const token = session?.user.authToken
+
+  try {
+    console.log(`${process.env.backendRoute}/api/v1/students/${email}`)
+    const res = await fetch(
+      `${process.env.backendRoute}/api/v1/students/${email}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        next: {
+          revalidate: 15,
+        },
+      },
+    )
+
+    if (!res.ok) {
+      return null
+    }
+
+    return res.json()
+  } catch (error) {
+    throw new Error('Erro de conexão com o servidor')
+  }
+}
+
+const StudentCollegeRecordPage = async ({ params }: { params: { username: string } }) => {
+	const studentData = await getData(`${params.username}@edge.ufal.br`)
+  if (!studentData) {
+    throw new Error('Erro ao buscar os dados')
+  }
+
+	const pdfSrc = `${process.env.awsUrl}/${process.env.awsBucket}/${studentData.academicRecordUrl}`;
+	
+  return (
+		<div className='w-full h-full flex flex-col items-center'>
+			{ studentData.academicRecordUrl ? 
+				( <StudentRecord pdfSrc={ pdfSrc }/>) :
+				( <StudentRecordFallback /> )
+			}
+		</div>
+  )
+}
+
+export default StudentCollegeRecordPage

--- a/src/app/(dashboard)/alunos/[username]/historico/page.tsx
+++ b/src/app/(dashboard)/alunos/[username]/historico/page.tsx
@@ -1,10 +1,8 @@
-/* eslint-disable prettier/prettier */
 'use server'
 
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import StudentRecord from '@/components/student-record/student-record'
-
 
 const getStudentData = async (email: string) => {
   const session = await getServerSession(authOptions)
@@ -34,7 +32,7 @@ const getStudentData = async (email: string) => {
   }
 }
 
-const checkPdfIsValid = async (academicRecordUrl : string) => {
+const checkPdfIsValid = async (academicRecordUrl: string) => {
   try {
     const res = await fetch(
       `${process.env.awsUrl}/${process.env.awsBucket}/${academicRecordUrl}`,
@@ -56,17 +54,21 @@ const checkPdfIsValid = async (academicRecordUrl : string) => {
   }
 }
 
-
-const StudentCollegeRecordPage = async ({ params }: { params: { username: string } }) => {
-	const studentData = await getStudentData(`${params.username}@edge.ufal.br`)
+const StudentCollegeRecordPage = async ({
+  params,
+}: {
+  params: { username: string }
+}) => {
+  const studentData = await getStudentData(`${params.username}@edge.ufal.br`)
   if (!studentData) {
     throw new Error('Erro ao buscar os dados')
   }
-  
+
   // a URL do PDF ficará nula caso o PDF esteja inacessível no S3
-  const pdfSrc = await checkPdfIsValid(studentData.academicRecordUrl) ? `${process.env.awsUrl}/${process.env.awsBucket}/${studentData.academicRecordUrl}` : '' 
-  
-  
+  const pdfSrc = (await checkPdfIsValid(studentData.academicRecordUrl))
+    ? `${process.env.awsUrl}/${process.env.awsBucket}/${studentData.academicRecordUrl}`
+    : ''
+
   return <StudentRecord studentData={studentData} pdfSrc={pdfSrc} />
 }
 

--- a/src/app/(dashboard)/alunos/[username]/historico/page.tsx
+++ b/src/app/(dashboard)/alunos/[username]/historico/page.tsx
@@ -1,11 +1,12 @@
+/* eslint-disable prettier/prettier */
 'use server'
 
 import { getServerSession } from 'next-auth'
-import { useSession } from 'next-auth/react'
 import { authOptions } from '@/lib/auth'
 import React from 'react'
 import StudentRecordFallback from '@/components/student-record/student-record-fallback'
 import StudentRecord from '@/components/student-record/student-record'
+import StudentRecordDialog from '@/components/student-record/student-record-dialog'
 
 const getData = async (email: string) => {
   const session = await getServerSession(authOptions)
@@ -45,12 +46,20 @@ const StudentCollegeRecordPage = async ({ params }: { params: { username: string
 	const pdfSrc = `${process.env.awsUrl}/${process.env.awsBucket}/${studentData.academicRecordUrl}`;
 	
   return (
-		<div className='w-full h-full flex flex-col items-center'>
-			{ studentData.academicRecordUrl ? 
-				( <StudentRecord pdfSrc={ pdfSrc }/>) :
-				( <StudentRecordFallback /> )
-			}
-		</div>
+    <div className='flex justify-center'>
+      <div className='max-w-[90vw] w-full flex flex-col px-10 py-5 h-full justify-center'>
+        <div className="flex flex-row justify-between my-5">
+          <h2 className="text-2xl font-bold">Histórico do Aluno</h2>
+          <StudentRecordDialog />
+        </div>
+        <div className='w-full h-full flex flex-col items-center'>
+          { studentData.academicRecordUrl ? 
+            ( <StudentRecord pdfSrc={ pdfSrc }/>) :
+            ( <StudentRecordFallback /> )
+          }
+        </div>
+      </div>
+    </div>   	
   )
 }
 

--- a/src/app/(dashboard)/alunos/[username]/notas/page.tsx
+++ b/src/app/(dashboard)/alunos/[username]/notas/page.tsx
@@ -32,13 +32,16 @@ const getNotas = async (email: string) => {
   const token = session?.user.authToken
 
   try {
-    const res = await fetch(`${process.env.backendRoute}/api/v1/grades/${email}`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
+    const res = await fetch(
+      `${process.env.backendRoute}/api/v1/grades/${email}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        next: { tags: ['disciplinas-table'], revalidate: 600 },
       },
-      next: { tags: ['disciplinas-table'], revalidate: 600 },
-    })
+    )
 
     if (!res.ok) {
       return null

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -4,3 +4,7 @@ import { revalidatePath } from 'next/cache'
 export async function revalidateUserPage(userId: string) {
   revalidatePath(`/alunos/${userId}/dados`, 'page')
 }
+
+export async function revalidateRecordPage(userId: string) {
+  revalidatePath(`/alunos/${userId}/historico`, 'page')
+}

--- a/src/components/student-page-header.tsx
+++ b/src/components/student-page-header.tsx
@@ -20,6 +20,7 @@ const StudentPageHeader = ({ student }: { student: Student }) => {
   const subpages: Array<SubpageData> = [
     { name: 'Dados pessoais', route: 'dados', active: false },
     { name: 'Notas', route: 'notas', active: false },
+    { name: 'Histórico', route: 'historico', active: false },
   ]
 
   // Gets the current loaded subpage route pathname and sets it as active

--- a/src/components/student-record/student-record-dialog.tsx
+++ b/src/components/student-record/student-record-dialog.tsx
@@ -88,6 +88,7 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey, studentData } : {p
 
 		setCanSaveRecord(true)
 	}
+
   return (
     <Dialog open={modalIsOpen} onOpenChange={changeModal}>
       <DialogTrigger asChild>
@@ -107,7 +108,7 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey, studentData } : {p
 						Insira seu histórico acadêmico em formato PDF, com tamanho
 						máximo de 2MB.
 					</div>
-					<div className="flex items-center justify-normal gap-x-2">
+					<div className="flex items-center py-2 justify-normal gap-x-2">
 						<Button size="lg" disabled={ !inputIsLoaded } type="button">
 							<input
 								type="file"
@@ -115,7 +116,7 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey, studentData } : {p
 								id="fileInput"
 								onChange={(e) => {
 									setSelectedRecord(e.target.files?.[0] || null)
-									setFileSizeIsBiggestThanMax(!!e.target.files?.[0] && e.target.files?.[0].size > 2 * MAX_RECORD_DOC_SIZE)
+									setFileSizeIsBiggestThanMax(!!e.target.files?.[0] && e.target.files?.[0].size > MAX_RECORD_DOC_SIZE)
 									setFileTypeIsPdf(!!e.target.files?.[0] && e.target.files?.[0].type === "application/pdf")
 								}}
 								accept="application/pdf"

--- a/src/components/student-record/student-record-dialog.tsx
+++ b/src/components/student-record/student-record-dialog.tsx
@@ -20,7 +20,7 @@ import { revalidateRecordPage } from '@/app/actions'
 import { getUsername } from '@/lib/utils'
 import { useToast } from "@/components/ui/use-toast"
 
-const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey } : {pdfViewerKey: number, setPdfViewerKey: (src: number) => void}) => {
+const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey, studentData } : {pdfViewerKey: number, setPdfViewerKey: (src: number) => void, studentData: any}) => {
 	const { data } = useSession()
 
 	const [selectedRecord, setSelectedRecord] = useState<File | null>()
@@ -31,6 +31,7 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey } : {pdfViewerKey: 
 	const [fileSizeIsBiggestThanMax, setFileSizeIsBiggestThanMax] = useState<boolean>(false)
 	const [fileTypeIsPdf, setFileTypeIsPdf] = useState<boolean>(true)
 	const [inputIsLoaded, setInputIsLoaded] = useState<boolean>(false)
+
 
 	const { toast } = useToast()
 
@@ -59,7 +60,7 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey } : {pdfViewerKey: 
 		formData.append('file', selectedRecord as Blob)
 
 		const response = await fetch(
-			`${process.env.backendRoute}/api/v1/students/${data?.user.email}/record`,
+			`${process.env.backendRoute}/api/v1/students/${studentData.email}/record`,
 			{
 				method: 'PUT',
 				body: formData,

--- a/src/components/student-record/student-record-dialog.tsx
+++ b/src/components/student-record/student-record-dialog.tsx
@@ -155,14 +155,14 @@ const StudentRecordDialog = ({
           <div>
             {isSaving && (
               <span className="text-muted-foreground text-sm">
-                Salvando no sistema, aguarde
+                Salvando no sistema, aguarde...
               </span>
             )}
           </div>
           <div>
             {fileSizeIsBiggestThanMax && (
               <span className="text-red-700 text-sm">
-                Arquivo maior que 2MB, favor enviar um menor
+                Arquivo maior que 2MB, favor enviar um menor.
               </span>
             )}
           </div>
@@ -170,7 +170,7 @@ const StudentRecordDialog = ({
             {!fileTypeIsPdf && (
               <span className="text-red-700 text-sm">
                 Arquivo é de extensão diferente que PDF, favor enviar um PDF
-                válido
+                válido.
               </span>
             )}
           </div>

--- a/src/components/student-record/student-record-dialog.tsx
+++ b/src/components/student-record/student-record-dialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 'use client'
 
 /* eslint-disable prettier/prettier */
@@ -14,7 +15,7 @@ import {
 import { Button } from '../ui/button'
 import { useSession } from 'next-auth/react'
 import { Upload } from 'lucide-react'
-import { use, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { revalidateRecordPage } from '@/app/actions'
 import { getUsername } from '@/lib/utils'
 import { useToast } from "@/components/ui/use-toast"
@@ -28,6 +29,7 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey } : {pdfViewerKey: 
 	const [modalIsOpen, setModalIsOpen] = useState<boolean>(false)
 	const [isSaving, setIsSaving] = useState<boolean>(false)
 	const [fileSizeIsBiggestThanMax, setFileSizeIsBiggestThanMax] = useState<boolean>(false)
+	const [fileTypeIsPdf, setFileTypeIsPdf] = useState<boolean>(true)
 	const [inputIsLoaded, setInputIsLoaded] = useState<boolean>(false)
 
 	const { toast } = useToast()
@@ -41,10 +43,15 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey } : {pdfViewerKey: 
 	// Dá um delay no carregamento do botão de Fazer Upload para evitar bugs de sincronização 
 	// e.g. (clicar e não abrir a janela de enviar arquivo)
 	useEffect(() => {
-    setTimeout(() => {
-      setInputIsLoaded(true);
-    }, 1500); 
-  }, []);
+		setTimeout(() => {
+		setInputIsLoaded(true);
+		}, 1500); 
+	}, []);
+
+	useEffect(() => {
+		setCanSaveRecord(!!selectedRecord && !fileSizeIsBiggestThanMax && fileTypeIsPdf);
+	}, [selectedRecord, fileSizeIsBiggestThanMax, fileTypeIsPdf]);
+	  
 
 	const submitHandler = async () => {
 		setCanSaveRecord(false)
@@ -106,8 +113,8 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey } : {pdfViewerKey: 
 								id="fileInput"
 								onChange={(e) => {
 									setSelectedRecord(e.target.files?.[0] || null)
-									setCanSaveRecord(!!e.target.files?.[0] && e.target.files?.[0].size < 2 * MAX_RECORD_DOC_SIZE)
 									setFileSizeIsBiggestThanMax(!!e.target.files?.[0] && e.target.files?.[0].size > 2 * MAX_RECORD_DOC_SIZE)
+									setFileTypeIsPdf(!!e.target.files?.[0] && e.target.files?.[0].type === "application/pdf")
 								}}
 								accept="application/pdf"
 							/>
@@ -135,6 +142,12 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey } : {pdfViewerKey: 
 						{
 							fileSizeIsBiggestThanMax &&
 							<span className='text-red-700 text-sm'>Arquivo maior que 2MB, favor enviar um menor</span>
+						}
+					</div>
+					<div>
+						{
+							!fileTypeIsPdf &&
+							<span className='text-red-700 text-sm'>Arquivo é de extensão diferente que PDF, favor enviar um PDF válido</span>
 						}
 					</div>
 				</div>

--- a/src/components/student-record/student-record-dialog.tsx
+++ b/src/components/student-record/student-record-dialog.tsx
@@ -57,6 +57,15 @@ const StudentRecordDialog = ({
     }, 1500)
   }, [])
 
+  // Dá um delay no carregamento do botão de Atualizar o Histórico para evitar bugs de sincronização do script
+  // e.g. (clicar e não abrir o modal)
+  const [dialogIsLoaded, setDialogIsLoaded] = useState<boolean>(false)
+  useEffect(() => {
+    setTimeout(() => {
+      setDialogIsLoaded(true)
+    }, 1000)
+  }, [])
+
   useEffect(() => {
     setCanSaveRecord(
       !!selectedRecord && !fileSizeIsBiggestThanMax && fileTypeIsPdf,
@@ -101,7 +110,7 @@ const StudentRecordDialog = ({
   return (
     <Dialog open={modalIsOpen} onOpenChange={changeModal}>
       <DialogTrigger asChild>
-        <Button>Atualizar o Histórico</Button>
+        <Button disabled={!dialogIsLoaded}>Atualizar o Histórico</Button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>

--- a/src/components/student-record/student-record-dialog.tsx
+++ b/src/components/student-record/student-record-dialog.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 'use client'
 
-/* eslint-disable prettier/prettier */
+import { revalidateRecordPage } from '@/app/actions'
 import {
   Dialog,
   DialogClose,
@@ -12,162 +12,185 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { Button } from '../ui/button'
-import { useSession } from 'next-auth/react'
-import { Upload } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { revalidateRecordPage } from '@/app/actions'
+import { useToast } from '@/components/ui/use-toast'
 import { getUsername } from '@/lib/utils'
-import { useToast } from "@/components/ui/use-toast"
+import { Upload } from 'lucide-react'
+import { useSession } from 'next-auth/react'
+import { useEffect, useState } from 'react'
+import { Button } from '../ui/button'
+import { Student } from '@/lib/domain'
 
-const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey, studentData } : {pdfViewerKey: number, setPdfViewerKey: (src: number) => void, studentData: any}) => {
-	const { data } = useSession()
+const StudentRecordDialog = ({
+  pdfViewerKey,
+  setPdfViewerKey,
+  studentData,
+}: {
+  pdfViewerKey: number
+  setPdfViewerKey: (src: number) => void
+  studentData: Student
+}) => {
+  const { data } = useSession()
 
-	const [selectedRecord, setSelectedRecord] = useState<File | null>()
-	const [canSaveRecord, setCanSaveRecord] = useState<boolean>(false)
-	const [error, setError] = useState<string | null>('')
-	const [modalIsOpen, setModalIsOpen] = useState<boolean>(false)
-	const [isSaving, setIsSaving] = useState<boolean>(false)
-	const [fileSizeIsBiggestThanMax, setFileSizeIsBiggestThanMax] = useState<boolean>(false)
-	const [fileTypeIsPdf, setFileTypeIsPdf] = useState<boolean>(true)
-	const [inputIsLoaded, setInputIsLoaded] = useState<boolean>(false)
+  const [selectedRecord, setSelectedRecord] = useState<File | null>()
+  const [canSaveRecord, setCanSaveRecord] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>('')
+  const [modalIsOpen, setModalIsOpen] = useState<boolean>(false)
+  const [isSaving, setIsSaving] = useState<boolean>(false)
+  const [fileSizeIsBiggestThanMax, setFileSizeIsBiggestThanMax] =
+    useState<boolean>(false)
+  const [fileTypeIsPdf, setFileTypeIsPdf] = useState<boolean>(true)
+  const [inputIsLoaded, setInputIsLoaded] = useState<boolean>(false)
 
+  const { toast } = useToast()
 
-	const { toast } = useToast()
+  const MAX_RECORD_DOC_SIZE = 2000000 // 2MB
 
-	const MAX_RECORD_DOC_SIZE = 2000000 // 2MB
+  const changeModal = () => {
+    setModalIsOpen(!modalIsOpen)
+  }
 
-	const changeModal = () => {
-		setModalIsOpen(!modalIsOpen)
-	}
+  // Dá um delay no carregamento do botão de Fazer Upload para evitar bugs de sincronização do script
+  // e.g. (clicar e não abrir a janela de enviar arquivo)
+  useEffect(() => {
+    setTimeout(() => {
+      setInputIsLoaded(true)
+    }, 1500)
+  }, [])
 
-	// Dá um delay no carregamento do botão de Fazer Upload para evitar bugs de sincronização do script
-	// e.g. (clicar e não abrir a janela de enviar arquivo)
-	useEffect(() => {
-		setTimeout(() => {
-		setInputIsLoaded(true);
-		}, 1500); 
-	}, []);
+  useEffect(() => {
+    setCanSaveRecord(
+      !!selectedRecord && !fileSizeIsBiggestThanMax && fileTypeIsPdf,
+    )
+  }, [selectedRecord, fileSizeIsBiggestThanMax, fileTypeIsPdf])
 
-	useEffect(() => {
-		setCanSaveRecord(!!selectedRecord && !fileSizeIsBiggestThanMax && fileTypeIsPdf);
-	}, [selectedRecord, fileSizeIsBiggestThanMax, fileTypeIsPdf]);
-	  
+  const submitHandler = async () => {
+    setCanSaveRecord(false)
+    const formData = new FormData()
+    formData.append('file', selectedRecord as Blob)
 
-	const submitHandler = async () => {
-		setCanSaveRecord(false)
-		const formData = new FormData()
-		formData.append('file', selectedRecord as Blob)
+    const response = await fetch(
+      `${process.env.backendRoute}/api/v1/students/${studentData.email}/record`,
+      {
+        method: 'PUT',
+        body: formData,
+        headers: {
+          Authorization: `Bearer ${data?.user.authToken}`,
+        },
+      },
+    )
 
-		const response = await fetch(
-			`${process.env.backendRoute}/api/v1/students/${studentData.email}/record`,
-			{
-				method: 'PUT',
-				body: formData,
-				headers: {
-					Authorization: `Bearer ${data?.user.authToken}`,
-				},
-			},
-		)
+    if (!response.ok) {
+      setError('Não foi possível salvar o histórico')
+    } else {
+      setError(null)
+      setIsSaving(true)
+      setSelectedRecord(null)
 
-		if (!response.ok) {
-			setError('Não foi possível salvar o histórico')
-		} else {
-			setError(null)
-			setIsSaving(true)
-			setSelectedRecord(null)
+      const studentResponse = await response.json()
+      revalidateRecordPage(getUsername(studentResponse.email)).then(() => {
+        setIsSaving(false)
+        setModalIsOpen(false)
+        setPdfViewerKey(Math.random())
+        toast({ description: 'Histórico atualizado.' })
+      })
+    }
 
-			const studentResponse = await response.json()
-			revalidateRecordPage(getUsername(studentResponse.email)).then(() => {
-				setIsSaving(false)
-				setModalIsOpen(false)
-				setPdfViewerKey(Math.random())
-				toast({description: "Histórico atualizado."})
-			})
-		}
-
-		setCanSaveRecord(true)
-	}
+    setCanSaveRecord(true)
+  }
 
   return (
     <Dialog open={modalIsOpen} onOpenChange={changeModal}>
       <DialogTrigger asChild>
-				<Button>Atualizar o Histórico</Button> 
-			</DialogTrigger>
+        <Button>Atualizar o Histórico</Button>
+      </DialogTrigger>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Atualizar o Histórico Acadêmico</DialogTitle>
           {error && (
-						<DialogDescription className="text-red-700">
-							{error}
-						</DialogDescription>
-					)}
+            <DialogDescription className="text-red-700">
+              {error}
+            </DialogDescription>
+          )}
         </DialogHeader>
-				<div className="space-y-2">
-					<div className="text-muted-foreground text-sm">
-						Insira seu histórico acadêmico em formato PDF, com tamanho
-						máximo de 2MB.
-					</div>
-					<div className="flex items-center py-2 justify-normal gap-x-2">
-						<Button size="lg" disabled={ !inputIsLoaded } type="button">
-							<input
-								type="file"
-								className="hidden"
-								id="fileInput"
-								onChange={(e) => {
-									setSelectedRecord(e.target.files?.[0] || null)
-									setFileSizeIsBiggestThanMax(!!e.target.files?.[0] && e.target.files?.[0].size > MAX_RECORD_DOC_SIZE)
-									setFileTypeIsPdf(!!e.target.files?.[0] && e.target.files?.[0].type === "application/pdf")
-								}}
-								accept="application/pdf"
-							/>
-							<label
-								htmlFor="fileInput"
-								className="text-neutral-90  rounded-md cursor-pointer inline-flex items-center"
-							>
-								<Upload className="mr-2" />
-								<span className="whitespace-nowrap">Fazer Upload</span>
-							</label>
-						</Button>
-					</div>
-					<div>
-						{ selectedRecord && 
-						<span className='text-muted-foreground text-sm'>Arquivo enviado: {selectedRecord.name}</span> 
-						}
-					</div>
-					<div>
-						{
-							isSaving &&
-							<span className='text-muted-foreground text-sm'>Salvando no sistema, aguarde</span>
-						}
-					</div>
-					<div>
-						{
-							fileSizeIsBiggestThanMax &&
-							<span className='text-red-700 text-sm'>Arquivo maior que 2MB, favor enviar um menor</span>
-						}
-					</div>
-					<div>
-						{
-							!fileTypeIsPdf &&
-							<span className='text-red-700 text-sm'>Arquivo é de extensão diferente que PDF, favor enviar um PDF válido</span>
-						}
-					</div>
-				</div>
-				<DialogFooter>
-					<DialogClose asChild>
-						<Button type="button" variant="secondary">
-							Fechar
-						</Button>
-					</DialogClose>
-					<Button
-						type="submit"
-						onClick={() => { submitHandler() }}
-						disabled={canSaveRecord === false}
-					>
-						Salvar
-					</Button>
-				</DialogFooter>
+        <div className="space-y-2">
+          <div className="text-muted-foreground text-sm">
+            Insira seu histórico acadêmico em formato PDF, com tamanho máximo de
+            2MB.
+          </div>
+          <div className="flex items-center py-2 justify-normal gap-x-2">
+            <Button size="lg" disabled={!inputIsLoaded} type="button">
+              <input
+                type="file"
+                className="hidden"
+                id="fileInput"
+                onChange={(e) => {
+                  setSelectedRecord(e.target.files?.[0] || null)
+                  setFileSizeIsBiggestThanMax(
+                    !!e.target.files?.[0] &&
+                      e.target.files?.[0].size > MAX_RECORD_DOC_SIZE,
+                  )
+                  setFileTypeIsPdf(
+                    !!e.target.files?.[0] &&
+                      e.target.files?.[0].type === 'application/pdf',
+                  )
+                }}
+                accept="application/pdf"
+              />
+              <label
+                htmlFor="fileInput"
+                className="text-neutral-90  rounded-md cursor-pointer inline-flex items-center"
+              >
+                <Upload className="mr-2" />
+                <span className="whitespace-nowrap">Fazer Upload</span>
+              </label>
+            </Button>
+          </div>
+          <div>
+            {selectedRecord && (
+              <span className="text-muted-foreground text-sm">
+                Arquivo enviado: {selectedRecord.name}
+              </span>
+            )}
+          </div>
+          <div>
+            {isSaving && (
+              <span className="text-muted-foreground text-sm">
+                Salvando no sistema, aguarde
+              </span>
+            )}
+          </div>
+          <div>
+            {fileSizeIsBiggestThanMax && (
+              <span className="text-red-700 text-sm">
+                Arquivo maior que 2MB, favor enviar um menor
+              </span>
+            )}
+          </div>
+          <div>
+            {!fileTypeIsPdf && (
+              <span className="text-red-700 text-sm">
+                Arquivo é de extensão diferente que PDF, favor enviar um PDF
+                válido
+              </span>
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="secondary">
+              Fechar
+            </Button>
+          </DialogClose>
+          <Button
+            type="submit"
+            onClick={() => {
+              submitHandler()
+            }}
+            disabled={canSaveRecord === false}
+          >
+            Salvar
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/src/components/student-record/student-record-dialog.tsx
+++ b/src/components/student-record/student-record-dialog.tsx
@@ -17,14 +17,18 @@ import { Upload } from 'lucide-react'
 import { useState } from 'react'
 import { revalidateRecordPage } from '@/app/actions'
 import { getUsername } from '@/lib/utils'
+import { useToast } from "@/components/ui/use-toast"
 
-const StudentRecordDialog = () => {
+const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey } : {pdfViewerKey: number, setPdfViewerKey: (src: number) => void}) => {
 	const { data } = useSession()
 
 	const [selectedRecord, setSelectedRecord] = useState<File | null>()
 	const [canSaveRecord, setCanSaveRecord] = useState<boolean>(false)
 	const [error, setError] = useState<string | null>('')
 	const [modalIsOpen, setModalIsOpen] = useState<boolean>(false)
+	const [isSaving, setIsSaving] = useState<boolean>(false)
+
+	const { toast } = useToast()
 
 	const changeModal = () => {
 		setModalIsOpen(!modalIsOpen)
@@ -49,10 +53,16 @@ const StudentRecordDialog = () => {
 		if (!response.ok) {
 			setError('Não foi possível salvar o histórico')
 		} else {
-			setModalIsOpen(false)
+			setIsSaving(true)
 			setSelectedRecord(null)
+
 			const studentResponse = await response.json()
-			await revalidateRecordPage(getUsername(studentResponse.email))
+			revalidateRecordPage(getUsername(studentResponse.email)).then(() => {
+				setIsSaving(false)
+				setModalIsOpen(false)
+				setPdfViewerKey(Math.random())
+				toast({description: "Histórico atualizado."})
+			})
 		}
 
 		setCanSaveRecord(true)
@@ -72,46 +82,57 @@ const StudentRecordDialog = () => {
 					)}
         </DialogHeader>
 				<div className="space-y-2">
-                <div className="text-muted-foreground text-sm">
-                  Insira seu histórico acadêmico em formato PDF, com tamanho
-                  máximo de 5MB.
-                </div>
-                <div className="flex items-center justify-normal gap-x-2">
-                  <Button size="lg" type="button">
-                    <input
-                      type="file"
-                      className="hidden"
-                      id="fileInput"
-                      onChange={(e) => {
-                        setSelectedRecord(e.target.files?.[0] || null)
-                        setCanSaveRecord(!!e.target.files?.[0])
-                      }}
-                      accept="application/pdf"
-                    />
-                    <label
-                      htmlFor="fileInput"
-                      className="text-neutral-90  rounded-md cursor-pointer inline-flex items-center"
-                    >
-                      <Upload className="mr-2" />
-                      <span className="whitespace-nowrap">Fazer Upload</span>
-                    </label>
-                  </Button>
-                </div>
-              </div>
-							<DialogFooter>
-								<DialogClose asChild>
-									<Button type="button" variant="secondary">
-										Fechar
-									</Button>
-								</DialogClose>
-								<Button
-									type="submit"
-									onClick={submitHandler}
-									disabled={canSaveRecord === false}
-								>
-									Salvar
-								</Button>
-							</DialogFooter>
+					<div className="text-muted-foreground text-sm">
+						Insira seu histórico acadêmico em formato PDF, com tamanho
+						máximo de 5MB.
+					</div>
+					<div className="flex items-center justify-normal gap-x-2">
+						<Button size="lg" type="button">
+							<input
+								type="file"
+								className="hidden"
+								id="fileInput"
+								onChange={(e) => {
+									setSelectedRecord(e.target.files?.[0] || null)
+									setCanSaveRecord(!!e.target.files?.[0])
+								}}
+								accept="application/pdf"
+							/>
+							<label
+								htmlFor="fileInput"
+								className="text-neutral-90  rounded-md cursor-pointer inline-flex items-center"
+							>
+								<Upload className="mr-2" />
+								<span className="whitespace-nowrap">Fazer Upload</span>
+							</label>
+						</Button>
+					</div>
+					<div>
+						{ selectedRecord && 
+						<span className='text-muted-foreground text-sm'>Arquivo enviado: {selectedRecord.name}</span> 
+						}
+					</div>
+					<div>
+						{
+							isSaving &&
+							<span className='text-muted-foreground text-sm'>Salvando no sistema, aguarde</span>
+						}
+					</div>
+				</div>
+				<DialogFooter>
+					<DialogClose asChild>
+						<Button type="button" variant="secondary">
+							Fechar
+						</Button>
+					</DialogClose>
+					<Button
+						type="submit"
+						onClick={() => { submitHandler() }}
+						disabled={canSaveRecord === false}
+					>
+						Salvar
+					</Button>
+				</DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/src/components/student-record/student-record-dialog.tsx
+++ b/src/components/student-record/student-record-dialog.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+/* eslint-disable prettier/prettier */
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Button } from '../ui/button'
+import { useSession } from 'next-auth/react'
+import { Upload } from 'lucide-react'
+import { useState } from 'react'
+import { revalidateRecordPage } from '@/app/actions'
+import { getUsername } from '@/lib/utils'
+
+const StudentRecordDialog = () => {
+	const { data } = useSession()
+
+	const [selectedRecord, setSelectedRecord] = useState<File | null>()
+	const [canSaveRecord, setCanSaveRecord] = useState<boolean>(false)
+	const [error, setError] = useState<string | null>('')
+	const [modalIsOpen, setModalIsOpen] = useState<boolean>(false)
+
+	const changeModal = () => {
+		setModalIsOpen(!modalIsOpen)
+	}
+
+	const submitHandler = async () => {
+			setCanSaveRecord(false)
+			const formData = new FormData()
+			formData.append('file', selectedRecord as Blob)
+
+			const response = await fetch(
+				`${process.env.backendRoute}/api/v1/students/${data?.user.email}/record`,
+			{
+				method: 'PUT',
+				body: formData,
+				headers: {
+					Authorization: `Bearer ${data?.user.authToken}`,
+				},
+			},
+		)
+
+		if (!response.ok) {
+			setError('Não foi possível salvar o histórico')
+		} else {
+			setModalIsOpen(false)
+			setSelectedRecord(null)
+			const studentResponse = await response.json()
+			await revalidateRecordPage(getUsername(studentResponse.email))
+		}
+
+		setCanSaveRecord(true)
+	}
+  return (
+    <Dialog open={modalIsOpen} onOpenChange={changeModal}>
+      <DialogTrigger asChild>
+				<Button>Atualizar o Histórico</Button> 
+			</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Atualizar o Histórico Acadêmico</DialogTitle>
+          {error && (
+						<DialogDescription className="text-red-700">
+							{error}
+						</DialogDescription>
+					)}
+        </DialogHeader>
+				<div className="space-y-2">
+                <div className="text-muted-foreground text-sm">
+                  Insira seu histórico acadêmico em formato PDF, com tamanho
+                  máximo de 5MB.
+                </div>
+                <div className="flex items-center justify-normal gap-x-2">
+                  <Button size="lg" type="button">
+                    <input
+                      type="file"
+                      className="hidden"
+                      id="fileInput"
+                      onChange={(e) => {
+                        setSelectedRecord(e.target.files?.[0] || null)
+                        setCanSaveRecord(!!e.target.files?.[0])
+                      }}
+                      accept="application/pdf"
+                    />
+                    <label
+                      htmlFor="fileInput"
+                      className="text-neutral-90  rounded-md cursor-pointer inline-flex items-center"
+                    >
+                      <Upload className="mr-2" />
+                      <span className="whitespace-nowrap">Fazer Upload</span>
+                    </label>
+                  </Button>
+                </div>
+              </div>
+							<DialogFooter>
+								<DialogClose asChild>
+									<Button type="button" variant="secondary">
+										Fechar
+									</Button>
+								</DialogClose>
+								<Button
+									type="submit"
+									onClick={submitHandler}
+									disabled={canSaveRecord === false}
+								>
+									Salvar
+								</Button>
+							</DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default StudentRecordDialog

--- a/src/components/student-record/student-record-dialog.tsx
+++ b/src/components/student-record/student-record-dialog.tsx
@@ -41,7 +41,7 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey, studentData } : {p
 		setModalIsOpen(!modalIsOpen)
 	}
 
-	// Dá um delay no carregamento do botão de Fazer Upload para evitar bugs de sincronização 
+	// Dá um delay no carregamento do botão de Fazer Upload para evitar bugs de sincronização do script
 	// e.g. (clicar e não abrir a janela de enviar arquivo)
 	useEffect(() => {
 		setTimeout(() => {
@@ -73,6 +73,7 @@ const StudentRecordDialog = ({ pdfViewerKey, setPdfViewerKey, studentData } : {p
 		if (!response.ok) {
 			setError('Não foi possível salvar o histórico')
 		} else {
+			setError(null)
 			setIsSaving(true)
 			setSelectedRecord(null)
 

--- a/src/components/student-record/student-record-fallback.tsx
+++ b/src/components/student-record/student-record-fallback.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const StudentRecordFallback = () => {
   return (
-    <div className='w-full h-full flex flex-col justify-center items-center text-center'>
+    <div className="w-full h-full flex flex-col justify-center items-center text-center">
       <p>Histórico não encontrado</p>
       <p>Que tal adicionar seu histórico mais atualizado?</p>
     </div>

--- a/src/components/student-record/student-record-fallback.tsx
+++ b/src/components/student-record/student-record-fallback.tsx
@@ -5,8 +5,6 @@ const StudentRecordFallback = ({
 }: {
   isAuthorizedUpdateRecord: boolean
 }) => {
-  console.log(isAuthorizedUpdateRecord)
-
   return (
     <div className="w-full h-full flex flex-col justify-center items-center text-center">
       <p>Histórico não encontrado.</p>

--- a/src/components/student-record/student-record-fallback.tsx
+++ b/src/components/student-record/student-record-fallback.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const StudentRecordFallback = () => {
+  return (
+    <div className='w-full h-full flex flex-col justify-center items-center text-center'>
+      <p>Histórico não encontrado</p>
+      <p>Que tal adicionar seu histórico mais atualizado?</p>
+    </div>
+  )
+}
+
+export default StudentRecordFallback

--- a/src/components/student-record/student-record-fallback.tsx
+++ b/src/components/student-record/student-record-fallback.tsx
@@ -1,10 +1,18 @@
 import React from 'react'
 
-const StudentRecordFallback = () => {
+const StudentRecordFallback = ({
+  isAuthorizedUpdateRecord,
+}: {
+  isAuthorizedUpdateRecord: boolean
+}) => {
+  console.log(isAuthorizedUpdateRecord)
+
   return (
     <div className="w-full h-full flex flex-col justify-center items-center text-center">
       <p>Histórico não encontrado.</p>
-      <p>Que tal adicionar seu histórico mais atualizado?</p>
+      {isAuthorizedUpdateRecord && (
+        <p>Que tal adicionar seu histórico mais atualizado?</p>
+      )}
     </div>
   )
 }

--- a/src/components/student-record/student-record-fallback.tsx
+++ b/src/components/student-record/student-record-fallback.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 const StudentRecordFallback = () => {
   return (
     <div className="w-full h-full flex flex-col justify-center items-center text-center">
-      <p>Histórico não encontrado</p>
+      <p>Histórico não encontrado.</p>
       <p>Que tal adicionar seu histórico mais atualizado?</p>
     </div>
   )

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import StudentRecordDialog from './student-record-dialog'
 import StudentRecordFallback from './student-record-fallback'
 import { Student } from '@/lib/domain'
+import { useSession } from 'next-auth/react'
 
 const StudentRecord = ({
   studentData,
@@ -14,6 +15,11 @@ const StudentRecord = ({
 }) => {
   // Isso eh utilizado para atualizar o embed toda vez que atualizar o historico
   const [pdfViewerKey, setPdfViewerKey] = useState(Math.random())
+  const user = useSession().data?.user
+  const isAuthorizedUpdateRecord =
+    user?.dtype === 'Student' && user?.email === studentData.email
+
+  console.log(isAuthorizedUpdateRecord)
 
   const dateRegex = /\d{4}-\d{2}-\d{2}/
   let date = null
@@ -43,11 +49,13 @@ const StudentRecord = ({
               {date && `Atualizado em: ${dateFormat.format(date)}`}
             </h3>
           </div>
-          <StudentRecordDialog
-            pdfViewerKey={pdfViewerKey}
-            setPdfViewerKey={setPdfViewerKey}
-            studentData={studentData}
-          />
+          {isAuthorizedUpdateRecord && (
+            <StudentRecordDialog
+              pdfViewerKey={pdfViewerKey}
+              setPdfViewerKey={setPdfViewerKey}
+              studentData={studentData}
+            />
+          )}
         </div>
         <div className="w-full h-full flex flex-col items-center">
           {studentData.academicRecordUrl ? (
@@ -70,7 +78,9 @@ const StudentRecord = ({
               )}
             </div>
           ) : (
-            <StudentRecordFallback />
+            <StudentRecordFallback
+              isAuthorizedUpdateRecord={isAuthorizedUpdateRecord}
+            />
           )}
         </div>
       </div>

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -1,11 +1,17 @@
-/* eslint-disable prettier/prettier */
 'use client'
 
 import { useState } from 'react'
 import StudentRecordDialog from './student-record-dialog'
 import StudentRecordFallback from './student-record-fallback'
+import { Student } from '@/lib/domain'
 
-const StudentRecord = ({ studentData, pdfSrc }: { studentData: any, pdfSrc: string}) => {
+const StudentRecord = ({
+  studentData,
+  pdfSrc,
+}: {
+  studentData: Student
+  pdfSrc: string
+}) => {
   // Isso eh utilizado para atualizar o embed toda vez que atualizar o historico
   const [pdfViewerKey, setPdfViewerKey] = useState(Math.random())
 
@@ -13,16 +19,14 @@ const StudentRecord = ({ studentData, pdfSrc }: { studentData: any, pdfSrc: stri
   let updatedAtFormatted = ''
 
   if (studentData.academicRecordUrl) {
-    const updatedAtMatch = studentData.academicRecordUrl.match(dateRegex);
-  
+    const updatedAtMatch = studentData.academicRecordUrl.match(dateRegex)
+
     if (updatedAtMatch) {
-      const [year, month, day] = updatedAtMatch[0].split('-');
+      const [year, month, day] = updatedAtMatch[0].split('-')
       // Format the date as DD/MM/YYYY
-      updatedAtFormatted = `${day}/${month}/${year}`;
+      updatedAtFormatted = `${day}/${month}/${year}`
     }
   }
-  
- 
 
   return (
     <div className="flex justify-center">

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -10,10 +10,16 @@ const StudentRecord = ({ studentData, pdfSrc }: { studentData: any, pdfSrc: stri
   const [pdfViewerKey, setPdfViewerKey] = useState(Math.random())
 
   const dateRegex = /\d{4}-\d{2}-\d{2}/
-  const updatedAt = studentData.academicRecordUrl.match(dateRegex)
-  const [year, month, day] = updatedAt[0].split('-')
-  // Formatar a data como DD/MM/YYYY
-  const updatedAtFormatted = `${day}/${month}/${year}`
+  let updatedAtFormatted = ''
+
+  if (studentData.academicRecordUrl) {
+    const updatedAt = studentData.academicRecordUrl && studentData.academicRecordUrl.match(dateRegex) 
+    const [year, month, day] = updatedAt[0].split('-')
+     // Formatar a data como DD/MM/YYYY
+    updatedAtFormatted = `${day}/${month}/${year}`
+  }
+  
+ 
 
   return (
     <div className="flex justify-center">
@@ -28,6 +34,7 @@ const StudentRecord = ({ studentData, pdfSrc }: { studentData: any, pdfSrc: stri
           <StudentRecordDialog
             pdfViewerKey={pdfViewerKey}
             setPdfViewerKey={setPdfViewerKey}
+            studentData={studentData}
           />
         </div>
         <div className="w-full h-full flex flex-col items-center">

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -1,12 +1,7 @@
-import React from 'react'
-
-const StudentRecord = ( { pdfSrc } :  {pdfSrc : string}) => {
+const StudentRecord = ({ pdfSrc }: { pdfSrc: string }) => {
   return (
-    <div className='max-w-[90vw] w-full px-10 py-5 justify-center flex flex-col'>
-        <div className='flex flex-row justify-between my-5'>
-					<h2 className='text-2xl font-bold'>Histórico do Aluno</h2>  
-        </div>
-        <iframe className='w-full h-screen' src={ pdfSrc }/>
+    <div className="w-full justify-center flex flex-col">
+      <iframe className="w-full h-screen" src={pdfSrc} />
     </div>
   )
 }

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const StudentRecord = ( { pdfSrc } :  {pdfSrc : string}) => {
+  return (
+    <div className='max-w-[90vw] w-full px-10 py-5 justify-center flex flex-col'>
+        <div className='flex flex-row justify-between my-5'>
+					<h2 className='text-2xl font-bold'>Histórico do Aluno</h2>  
+        </div>
+        <iframe className='w-full h-screen' src={ pdfSrc }/>
+    </div>
+  )
+}
+
+export default StudentRecord

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -16,15 +16,20 @@ const StudentRecord = ({
   const [pdfViewerKey, setPdfViewerKey] = useState(Math.random())
 
   const dateRegex = /\d{4}-\d{2}-\d{2}/
-  let updatedAtFormatted = ''
+  let date = null
+
+  const dateFormat = new Intl.DateTimeFormat('pt-br', {
+    dateStyle: 'long',
+    timeStyle: undefined,
+  })
 
   if (studentData.academicRecordUrl) {
-    const updatedAtMatch = studentData.academicRecordUrl.match(dateRegex)
-
+    const updatedAtMatch =
+      studentData.academicRecordUrl.match(dateRegex)?.toString() +
+      'T00:00:00.000-0300' // ajusta o fuso horário para Brasília
+    console.log(updatedAtMatch)
     if (updatedAtMatch) {
-      const [year, month, day] = updatedAtMatch[0].split('-')
-      // Format the date as DD/MM/YYYY
-      updatedAtFormatted = `${day}/${month}/${year}`
+      date = new Date(updatedAtMatch)
     }
   }
 
@@ -35,7 +40,7 @@ const StudentRecord = ({
           <div className="flex flex-col">
             <h2 className="text-2xl font-bold">Histórico do Aluno</h2>
             <h3 className="text-muted-foreground">
-              Atualizado em: {updatedAtFormatted}
+              {date && `Atualizado em: ${dateFormat.format(date)}`}
             </h3>
           </div>
           <StudentRecordDialog

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -19,8 +19,6 @@ const StudentRecord = ({
   const isAuthorizedUpdateRecord =
     user?.dtype === 'Student' && user?.email === studentData.email
 
-  console.log(isAuthorizedUpdateRecord)
-
   const dateRegex = /\d{4}-\d{2}-\d{2}/
   let date = null
 
@@ -33,7 +31,6 @@ const StudentRecord = ({
     const updatedAtMatch =
       studentData.academicRecordUrl.match(dateRegex)?.toString() +
       'T00:00:00.000-0300' // ajusta o fuso horário para Brasília
-    console.log(updatedAtMatch)
     if (updatedAtMatch) {
       date = new Date(updatedAtMatch)
     }

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -5,7 +5,8 @@ import StudentRecordDialog from "./student-record-dialog"
 import StudentRecordFallback from "./student-record-fallback"
 
 const StudentRecord = ({ studentData, pdfSrc }: { studentData: any, pdfSrc: string }) => {
-  const [pdfViewerKey, setPdfViewerKey] = useState(Math.random())
+  // Isso eh utilizado para atualizar o embed toda vez que atualizar o historico
+  const [pdfViewerKey, setPdfViewerKey] = useState(Math.random()) 
 
   return (
     <div className='flex justify-center'>

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -1,31 +1,61 @@
+/* eslint-disable prettier/prettier */
 'use client'
 
-import { useState } from "react"
-import StudentRecordDialog from "./student-record-dialog"
-import StudentRecordFallback from "./student-record-fallback"
+import { useState } from 'react'
+import StudentRecordDialog from './student-record-dialog'
+import StudentRecordFallback from './student-record-fallback'
 
-const StudentRecord = ({ studentData, pdfSrc }: { studentData: any, pdfSrc: string }) => {
+const StudentRecord = ({ studentData, pdfSrc }: { studentData: any, pdfSrc: string}) => {
   // Isso eh utilizado para atualizar o embed toda vez que atualizar o historico
-  const [pdfViewerKey, setPdfViewerKey] = useState(Math.random()) 
+  const [pdfViewerKey, setPdfViewerKey] = useState(Math.random())
+
+  const dateRegex = /\d{4}-\d{2}-\d{2}/
+  const updatedAt = studentData.academicRecordUrl.match(dateRegex)
+  const [year, month, day] = updatedAt[0].split('-')
+  // Formatar a data como DD/MM/YYYY
+  const updatedAtFormatted = `${day}/${month}/${year}`
 
   return (
-    <div className='flex justify-center'>
-      <div className='max-w-[90vw] w-full flex flex-col px-10 py-5 h-full justify-center'>
-        <div className="flex flex-row justify-between my-5">
-          <h2 className="text-2xl font-bold">Histórico do Aluno</h2>
-          <StudentRecordDialog pdfViewerKey={ pdfViewerKey } setPdfViewerKey={ setPdfViewerKey }/>
+    <div className="flex justify-center">
+      <div className="max-w-[90vw] w-full flex flex-col px-10 py-5 h-full justify-center">
+        <div className="flex flex-row justify-between my-5 items-center">
+          <div className="flex flex-col">
+            <h2 className="text-2xl font-bold">Histórico do Aluno</h2>
+            <h3 className="text-muted-foreground">
+              Atualizado em: {updatedAtFormatted}
+            </h3>
+          </div>
+          <StudentRecordDialog
+            pdfViewerKey={pdfViewerKey}
+            setPdfViewerKey={setPdfViewerKey}
+          />
         </div>
-        <div className='w-full h-full flex flex-col items-center'>
-          { studentData.academicRecordUrl ? 
-            ( <div className="w-full justify-center flex flex-col">
-                <embed className="w-full h-screen" src={ pdfSrc } key={ pdfViewerKey } />
-              </div>
-            ) :
-            ( <StudentRecordFallback /> )
-          }
+        <div className="w-full h-full flex flex-col items-center">
+          {studentData.academicRecordUrl ? (
+            <div className="w-full justify-center flex flex-col items-center">
+              {pdfSrc ? (
+                <embed
+                  className="w-full h-screen"
+                  src={pdfSrc}
+                  key={pdfViewerKey}
+                  type="application/pdf"
+                />
+              ) : (
+                <div className="flex items-start justify-center h-32">
+                  <p className="text-center w-[40rem] text-red-700">
+                    Se você está vendo esta mensagem ou o seu navegador não tem
+                    suporte a visualizar PDF ou o arquivo do histórico do aluno
+                    está corrompido.
+                  </p>
+                </div>
+              )}
+            </div>
+          ) : (
+            <StudentRecordFallback />
+          )}
         </div>
       </div>
-    </div>   
+    </div>
   )
 }
 

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -13,10 +13,13 @@ const StudentRecord = ({ studentData, pdfSrc }: { studentData: any, pdfSrc: stri
   let updatedAtFormatted = ''
 
   if (studentData.academicRecordUrl) {
-    const updatedAt = studentData.academicRecordUrl && studentData.academicRecordUrl.match(dateRegex) 
-    const [year, month, day] = updatedAt[0].split('-')
-     // Formatar a data como DD/MM/YYYY
-    updatedAtFormatted = `${day}/${month}/${year}`
+    const updatedAtMatch = studentData.academicRecordUrl.match(dateRegex);
+  
+    if (updatedAtMatch) {
+      const [year, month, day] = updatedAtMatch[0].split('-');
+      // Format the date as DD/MM/YYYY
+      updatedAtFormatted = `${day}/${month}/${year}`;
+    }
   }
   
  

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -1,8 +1,30 @@
-const StudentRecord = ({ pdfSrc }: { pdfSrc: string }) => {
+'use client'
+
+import { useState } from "react"
+import StudentRecordDialog from "./student-record-dialog"
+import StudentRecordFallback from "./student-record-fallback"
+
+const StudentRecord = ({ studentData, pdfSrc }: { studentData: any, pdfSrc: string }) => {
+  const [pdfViewerKey, setPdfViewerKey] = useState(Math.random())
+
   return (
-    <div className="w-full justify-center flex flex-col">
-      <iframe className="w-full h-screen" src={pdfSrc} />
-    </div>
+    <div className='flex justify-center'>
+      <div className='max-w-[90vw] w-full flex flex-col px-10 py-5 h-full justify-center'>
+        <div className="flex flex-row justify-between my-5">
+          <h2 className="text-2xl font-bold">Histórico do Aluno</h2>
+          <StudentRecordDialog pdfViewerKey={ pdfViewerKey } setPdfViewerKey={ setPdfViewerKey }/>
+        </div>
+        <div className='w-full h-full flex flex-col items-center'>
+          { studentData.academicRecordUrl ? 
+            ( <div className="w-full justify-center flex flex-col">
+                <embed className="w-full h-screen" src={ pdfSrc } key={ pdfViewerKey } />
+              </div>
+            ) :
+            ( <StudentRecordFallback /> )
+          }
+        </div>
+      </div>
+    </div>   
   )
 }
 

--- a/src/components/student-record/student-record.tsx
+++ b/src/components/student-record/student-record.tsx
@@ -27,7 +27,7 @@ const StudentRecord = ({ studentData, pdfSrc }: { studentData: any, pdfSrc: stri
   return (
     <div className="flex justify-center">
       <div className="max-w-[90vw] w-full flex flex-col px-10 py-5 h-full justify-center">
-        <div className="flex flex-row justify-between my-5 items-center">
+        <div className="flex flex-row justify-between mb-5 items-center">
           <div className="flex flex-col">
             <h2 className="text-2xl font-bold">Histórico do Aluno</h2>
             <h3 className="text-muted-foreground">

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -2,6 +2,7 @@ export type Student = {
   id: string
   name: string
   photoUrl: string
+  academicRecordUrl: string
   birthDate: string
   course: string
   registration: string

--- a/src/lib/functions/http/edit-info-req.ts
+++ b/src/lib/functions/http/edit-info-req.ts
@@ -29,8 +29,6 @@ export const editInfo = async (data: any) => {
       throw new Error('Erro ao editar os dados')
     }
 
-    console.log('RESULAOTO', res.json())
-
     revalidateTag('user-data')
 
     return {


### PR DESCRIPTION
> Peço desculpas antecipadamente por não ter dividido essa PR entre as histórias de usuário, pois acabei trabalhando meio que em todas elas ao mesmo tempo, e muito dos commits possuem alteração em diversas partes das histórias. 
>
> ![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/dd1a8be1-c71c-40dd-92fa-dcf468cd6ecf)

Foi criado uma nova página no sistema na rota `/alunos/{username}/historico` para visualização e atualização do histórico acadêmico do aluno.

Esta é a visualização padrão quando o aluno não possui histórico atrelado:

![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/cf494f1d-30b3-410a-ab64-7788dea44eac)

Ao clicar no botão de atualizar o histórico é exibido um modal de upload:

![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/7db87a7e-0bf5-46c3-97dd-0beb1b18222d)

Duas validações foram inseridas conforme os critérios de aceite da história:

> I. Tamanho do arquivo deve ser menor que 2MB, logo ao enviar um arquivo maior de 2MB é exibido um aviso ao usuário e o botão de salvar permanece disabled
>
> ![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/4c7010e9-be0b-468d-9cf0-1ced87cee718)
>
> II. O arquivo deve ser PDF, caso o usuário envie algum arquivo diferente é exibido um aviso e o botão de salvar permanece disabled
>
> ![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/06dd1eba-4e02-4792-bb3e-5db14acc5338)

Ao enviar um arquivo válido, o usuário poderá salvar o histórico, enviando o arquivo para o back-end que irá lidar de salvar no storage.

![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/8aca70ec-7fb1-4c93-ba62-34d2e2afa4db)

Ao salvar, o cache é revalidado e a página é atualizada para exibir o histórico

![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/8809d190-8204-44a8-9669-06301a5bba58)

O mesmo funciona também caso já haja um histórico, atualizando para o mais recente

![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/92347664-9435-4d2d-85d6-30171461dbda)

> Obs. pode haver um bug de não atualizar corretamente o histórico, não consegui replicar muito bem isto, parece que ocorre quando há uma recompilação no Next, ou quando o usuário recém loga no sistema, de modo que o script não seja carregado totalmente (ou algo do tipo). Em geral o sistema de atualizar o componente funciona 90% dos casos, e quando não funcionar um F5 parece resolver. Eu tentei analisar o código e pelo que eu vi não há nada que indique um problema. Adicionei alguns mecanismos para garantir que essa atualização ocorra, como key aleatória no componente do embed que atualiza conforme o usuário atualiza o histórico, revalidate time de 0 para o fetch dos dados do estudantes (forçando o sistema a não cachear esses dados nesta página) e um revalidatePath após atualizar o histórico.

Também foi incluído um fallback para quando o histórico do aluno foi corrompido (em geral, esse fallback irá acontecer quando o storage retornar um erro ao tentar acessar o arquivo, que é verificado durante o carregamento da página e passado para o componente de visualização do histórico)

![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/b90f6233-a712-4907-8fee-03a0b9f7b5ea)

> Este resultado pode ser obtido ao excluir o arquivo do assets do localstack sem remover a URL do banco.

O histórico pode ser atualizado normalmente para corrigir o erro caso o arquivo esteja corrompido.

Com relação aos critérios de aceite de zoom e download, estes elementos estão presentes nos visualizadores de PDF da maioria dos navegadores. Eu testei com Firefox (o mesmo dos prints), Chrome e Edge, e todos funcionaram normalmente e tinha estas funcionalidades. Imagino que esteja presente nos demais mais usados (Brave, Vivaldi, Safari, etc). 

Não utilizei componentes extras para visualizar o PDF pois a maioria tive problemas de compatibilidade com o NextJS e com o pnpm, então decidi utilizar apenas o embed nativo dos navegadores.

![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/2fa7ab60-fa24-4e75-b09f-eb30049ca24f)
Agradeço desde já quem vai revisar essa PR (pois deve dar trabalho). 
![image](https://github.com/Edge-Academy-UFAL/student-manager-ui/assets/108153768/e756ac04-7507-414a-8899-01312f5aa639)











